### PR TITLE
Fix hook and callback delivery failure handling

### DIFF
--- a/src/CaptainHook.EventHandlerActor/EventHandlerActor.cs
+++ b/src/CaptainHook.EventHandlerActor/EventHandlerActor.cs
@@ -106,7 +106,7 @@ namespace CaptainHook.EventHandlerActor
                 }
 
                 var handler = _eventHandlerFactory.CreateEventHandler(messageData.Type, messageData.SubscriberName);
-                await handler.CallAsync(messageData, new Dictionary<string, object>(), CancellationToken.None);
+                messageDelivered = await handler.CallAsync(messageData, new Dictionary<string, object>(), CancellationToken.None);
             }
             catch (Exception e)
             {

--- a/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
@@ -51,7 +51,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
         /// <param name="metadata"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public virtual async Task CallAsync<TRequest>(TRequest request, IDictionary<string, object> metadata, CancellationToken cancellationToken)
+        public virtual async Task<bool> CallAsync<TRequest>(TRequest request, IDictionary<string, object> metadata, CancellationToken cancellationToken)
         {
             try
             {
@@ -79,6 +79,8 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 var response = await httpClient.SendRequestReliablyAsync(httpMethod, uri, headers, payload, cancellationToken);
 
                 await _requestLogger.LogAsync(httpClient, response, messageData, uri, httpMethod, headers);
+
+                return !response.IsDeliveryFailure();
             }
             catch (Exception e)
             {

--- a/src/CaptainHook.EventHandlerActor/Handlers/HttpClientExtensions.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/HttpClientExtensions.cs
@@ -66,21 +66,21 @@ namespace CaptainHook.EventHandlerActor.Handlers
         private static async Task<HttpResponseMessage> RetryRequest(
             Func<Task<HttpResponseMessage>> makeTheCall)
         {
+            
             //todo the retry status codes need to be customisable from the webhook config api
             var response = await Policy.HandleResult<HttpResponseMessage>(
-                    message =>
-                        message.StatusCode == HttpStatusCode.ServiceUnavailable ||
-                        message.StatusCode == HttpStatusCode.TooManyRequests)
+                    message => message.IsDeliveryFailure())                      
 
                 .WaitAndRetryAsync(new[]
                 {
                     //todo config this + jitter
                     TimeSpan.FromSeconds(20),
                     TimeSpan.FromSeconds(30)
-
                 }).ExecuteAsync(makeTheCall.Invoke);
-
+        
             return response;
         }
+
+       
     }
 }

--- a/src/CaptainHook.EventHandlerActor/Handlers/HttpClientExtensions.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/HttpClientExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -65,12 +64,10 @@ namespace CaptainHook.EventHandlerActor.Handlers
         /// <returns></returns>
         private static async Task<HttpResponseMessage> RetryRequest(
             Func<Task<HttpResponseMessage>> makeTheCall)
-        {
-            
+        {            
             //todo the retry status codes need to be customisable from the webhook config api
             var response = await Policy.HandleResult<HttpResponseMessage>(
                     message => message.IsDeliveryFailure())                      
-
                 .WaitAndRetryAsync(new[]
                 {
                     //todo config this + jitter
@@ -79,8 +76,6 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 }).ExecuteAsync(makeTheCall.Invoke);
         
             return response;
-        }
-
-       
+        }       
     }
 }

--- a/src/CaptainHook.EventHandlerActor/Handlers/HttpResponseMessageExtensions.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/HttpResponseMessageExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace CaptainHook.EventHandlerActor.Handlers
+{
+    public static class HttpResponseMessageExtensions
+    {
+        /// <summary>
+        /// define "delivery failure" for the EDA context
+        /// </summary>
+        /// <param name="response">response object</param>
+        /// <returns>true if response indicates EDA delivery failure</returns>
+        public static bool IsDeliveryFailure(this HttpResponseMessage response) => response !=null && ((response.StatusCode >= HttpStatusCode.InternalServerError && response.StatusCode <= HttpStatusCode.NetworkAuthenticationRequired) || response.StatusCode == HttpStatusCode.TooManyRequests);
+    }
+}

--- a/src/CaptainHook.EventHandlerActor/Handlers/IHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/IHandler.cs
@@ -4,8 +4,19 @@ using System.Threading.Tasks;
 
 namespace CaptainHook.EventHandlerActor.Handlers
 {
+    /// <summary>
+    /// request/response handler interface
+    /// </summary>
     public interface IHandler
     {
-        Task CallAsync<TRequest>(TRequest request, IDictionary<string, object> metaData, CancellationToken cancellationToken);
+        /// <summary>
+        /// handle request
+        /// </summary>
+        /// <typeparam name="TRequest">type of incoming structure</typeparam>
+        /// <param name="request">incoming data instance</param>
+        /// <param name="metaData">header key value pair</param>
+        /// <param name="cancellationToken">cancellation token</param>
+        /// <returns>true for operation success</returns>
+        Task<bool> CallAsync<TRequest>(TRequest request, IDictionary<string, object> metaData, CancellationToken cancellationToken);
     }
 }

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/HttpResponseMessageTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/HttpResponseMessageTests.cs
@@ -1,0 +1,35 @@
+﻿using Eshopworld.Tests.Core;
+using System.Net;
+using System.Net.Http;
+using Xunit;
+using CaptainHook.EventHandlerActor.Handlers;
+
+namespace CaptainHook.Tests.Web.WebHooks
+{
+    public class HttpResponseMessageTests
+    {
+        [Theory, IsLayer0]
+        [InlineData(HttpStatusCode.InternalServerError, true)]
+        [InlineData(HttpStatusCode.NotImplemented, true)]
+        [InlineData(HttpStatusCode.BadGateway, true)]
+        [InlineData(HttpStatusCode.ServiceUnavailable, true)]
+        [InlineData(HttpStatusCode.GatewayTimeout, true)]
+        [InlineData(HttpStatusCode.HttpVersionNotSupported, true)]
+        [InlineData(HttpStatusCode.VariantAlsoNegotiates, true)]
+        [InlineData(HttpStatusCode.InsufficientStorage, true)]
+        [InlineData(HttpStatusCode.LoopDetected, true)]
+        [InlineData(HttpStatusCode.NotExtended, true)]
+        [InlineData(HttpStatusCode.NetworkAuthenticationRequired, true)]
+        [InlineData(HttpStatusCode.TooManyRequests, true)]
+        [InlineData(HttpStatusCode.OK, false)]
+        [InlineData(HttpStatusCode.NoContent, false)]
+        [InlineData(HttpStatusCode.Created, false)]
+        [InlineData(HttpStatusCode.BadRequest, false)]
+        [InlineData(HttpStatusCode.NotModified, false)]
+        public void IsDeliveryFailureAllPossibleCodesTests(HttpStatusCode input, bool expectedResult)
+        {
+            Assert.True(expectedResult == new HttpResponseMessage(input).IsDeliveryFailure());
+        }
+    }
+}
+

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
-    <add key="repositoryPath" value="..\packages" />
+    <add key="repositoryPath" value="packages" />
   </config>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />


### PR DESCRIPTION
This changes the flow for new definition of codes that are considered "failed delivery"  - 5XX and 429

also repointed packages folder to structure to match what is in the sfproj file