### PR TITLE
#57444 - configure connection with CosmosDB

### DIFF
--- a/src/CaptainHook.Database/Setup/CosmosDbConfigurationExtensions.cs
+++ b/src/CaptainHook.Database/Setup/CosmosDbConfigurationExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Autofac;
+using CaptainHook.Database.CosmosDB;
+using Microsoft.Extensions.Configuration;
+
+namespace CaptainHook.Database.Setup
+{
+    /// <summary>
+    /// Extension class to wrap configuration of CosmosDB
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class CosmosDbConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures Cosmos DB from existing config store.
+        /// </summary>
+        public static ContainerBuilder ConfigureCosmosDb(this ContainerBuilder builder, IConfiguration configuration)
+        {
+            var cosmosDbConfiguration = configuration.GetSection("DbConfiguration").Get<CosmosDbConfiguration>() ?? new CosmosDbConfiguration();
+            var (dbEndpoint, dbKey) = DbSettingsParser.GetDbSettings(configuration);
+            cosmosDbConfiguration.DatabaseEndpoint = dbEndpoint;
+            cosmosDbConfiguration.DatabaseKey = dbKey;
+
+            builder.RegisterInstance(cosmosDbConfiguration);
+
+            return builder;
+        }
+    }
+}

--- a/src/CaptainHook.Database/Setup/DbSettingsParser.cs
+++ b/src/CaptainHook.Database/Setup/DbSettingsParser.cs
@@ -14,15 +14,11 @@ namespace CaptainHook.Database.Setup
     public static class DbSettingsParser
     {
         private const string ConnectionStringKey = "CosmosDB:Tooling:ConnectionString";
+
         private const string EndPointKey = "AccountEndpoint";
+
         private const string AccountKey = "AccountKey";
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="configuration"></param>
-        /// <exception cref="CosmosDbConfigurationException"></exception>
-        /// <returns></returns>
         public static (string dbEndpoint, string dbKey) GetDbSettings(IConfiguration configuration)
         {
             var connectionString = configuration[ConnectionStringKey];
@@ -34,9 +30,9 @@ namespace CaptainHook.Database.Setup
             var connectionStringBuilder = new DbConnectionStringBuilder { ConnectionString = connectionString };
 
             var dbEndpoint = GetDbEndpoint(connectionStringBuilder);
-            var databaseKey = GetDatabaseKey(connectionStringBuilder);
+            var dbKey = GetDatabaseKey(connectionStringBuilder);
 
-            return (dbEndpoint: dbEndpoint, dbKey: databaseKey);
+            return (dbEndpoint, dbKey);
         }
 
         private static string GetDatabaseKey(DbConnectionStringBuilder connectionStringBuilder)

--- a/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
+++ b/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="3.4.677" />
   </ItemGroup>
 

--- a/src/CaptainHook.DirectorService/PackageRoot/ServiceManifest.xml
+++ b/src/CaptainHook.DirectorService/PackageRoot/ServiceManifest.xml
@@ -20,7 +20,7 @@
     <EnvironmentVariables>
       <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="N/A" />
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="N/A" />
-      <EnvironmentVariable Name="EDA_CosmosDB:Tooling:ConnectionString" Value="" />
+      <EnvironmentVariable Name="CosmosDB:Tooling:ConnectionString" Value="" />
     </EnvironmentVariables>
   </CodePackage>
 

--- a/src/CaptainHook.DirectorService/PackageRoot/ServiceManifest.xml
+++ b/src/CaptainHook.DirectorService/PackageRoot/ServiceManifest.xml
@@ -20,6 +20,7 @@
     <EnvironmentVariables>
       <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="N/A" />
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="N/A" />
+      <EnvironmentVariable Name="EDA_CosmosDB:Tooling:ConnectionString" Value="" />
     </EnvironmentVariables>
   </CodePackage>
 

--- a/src/CaptainHook.DirectorService/Program.cs
+++ b/src/CaptainHook.DirectorService/Program.cs
@@ -34,7 +34,7 @@ namespace CaptainHook.DirectorService
                         kvUri,
                         new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback)),
                         new DefaultKeyVaultSecretManager())
-                    .AddEnvironmentVariables("EDA_")
+                    .AddEnvironmentVariables()
                     .Build();
 
                 var settings = new ConfigurationSettings();

--- a/src/CaptainHook.DirectorService/Program.cs
+++ b/src/CaptainHook.DirectorService/Program.cs
@@ -9,6 +9,7 @@ using Autofac.Integration.ServiceFabric;
 using CaptainHook.Common;
 using CaptainHook.Common.Configuration;
 using CaptainHook.Common.Telemetry;
+using CaptainHook.Database.Setup;
 using Eshopworld.Telemetry;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
@@ -28,11 +29,13 @@ namespace CaptainHook.DirectorService
             {
                 var kvUri = Environment.GetEnvironmentVariable(ConfigurationSettings.KeyVaultUriEnvVariable);
 
-                var config = new ConfigurationBuilder().AddAzureKeyVault(
-                                                           kvUri,
-                                                           new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback)),
-                                                           new DefaultKeyVaultSecretManager())
-                                                       .Build();
+                var config = new ConfigurationBuilder()
+                    .AddAzureKeyVault(
+                        kvUri,
+                        new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback)),
+                        new DefaultKeyVaultSecretManager())
+                    .AddEnvironmentVariables("EDA_")
+                    .Build();
 
                 var settings = new ConfigurationSettings();
                 config.Bind(settings);
@@ -48,6 +51,11 @@ namespace CaptainHook.DirectorService
 
                 builder.RegisterInstance(config.GetSection("event").Get<IEnumerable<EventHandlerConfig>>());
 
+                // CosmosDB support is under development
+                if (false)
+                {
+                    builder.ConfigureCosmosDb(config);
+                }
 
                 builder.RegisterInstance(settings)
                        .SingleInstance();

--- a/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="CaptainHookType" ApplicationTypeVersion="1.0.0" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="KeyVault_Base_Uri" DefaultValue="N/A" />
@@ -10,6 +10,7 @@
     <Parameter Name="CaptainHook.DirectorService_MinReplicaSetSize" DefaultValue="3" />
     <Parameter Name="CaptainHook.DirectorService_PartitionCount" DefaultValue="1" />
     <Parameter Name="CaptainHook.DirectorService_TargetReplicaSetSize" DefaultValue="3" />
+    <Parameter Name="EDA_CosmosDb_ConnectionString" DefaultValue="" />
   </Parameters>
   <!-- Import the ServiceManifest from the ServicePackage. The ServiceManifestName and ServiceManifestVersion 
        should match the Name and Version attributes of the ServiceManifest element defined in the 
@@ -45,6 +46,7 @@
     <EnvironmentOverrides CodePackageRef="Code">
       <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="[KeyVault_Base_Uri]" />
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="[AspNetCore_Environment]" />
+      <EnvironmentVariable Name="EDA_CosmosDB:Tooling:ConnectionString" Value="[EDA_CosmosDb_ConnectionString]" />
     </EnvironmentOverrides>
   </ServiceManifestImport>
   <DefaultServices>

--- a/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
@@ -10,7 +10,7 @@
     <Parameter Name="CaptainHook.DirectorService_MinReplicaSetSize" DefaultValue="3" />
     <Parameter Name="CaptainHook.DirectorService_PartitionCount" DefaultValue="1" />
     <Parameter Name="CaptainHook.DirectorService_TargetReplicaSetSize" DefaultValue="3" />
-    <Parameter Name="EDA_CosmosDb_ConnectionString" DefaultValue="" />
+    <Parameter Name="CosmosDb_Tooling_ConnectionString" DefaultValue="" />
   </Parameters>
   <!-- Import the ServiceManifest from the ServicePackage. The ServiceManifestName and ServiceManifestVersion 
        should match the Name and Version attributes of the ServiceManifest element defined in the 
@@ -46,7 +46,7 @@
     <EnvironmentOverrides CodePackageRef="Code">
       <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="[KeyVault_Base_Uri]" />
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="[AspNetCore_Environment]" />
-      <EnvironmentVariable Name="EDA_CosmosDB:Tooling:ConnectionString" Value="[EDA_CosmosDb_ConnectionString]" />
+      <EnvironmentVariable Name="CosmosDB:Tooling:ConnectionString" Value="[CosmosDb_Tooling_ConnectionString]" />
     </EnvironmentOverrides>
   </ServiceManifestImport>
   <DefaultServices>

--- a/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
+++ b/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/CaptainHook" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="KeyVault_Base_Uri" Value="https://esw-tooling-ci-we.vault.azure.net/" />
@@ -9,5 +9,7 @@
     <Parameter Name="CaptainHook.DirectorService_DefaultMinReplicaSetSize" Value="1"/>
     <Parameter Name="CaptainHook.DirectorService_DefaultTargetReplicaSetSize" Value="1"/>
     <Parameter Name="CaptainHook.DirectorService_DefaultPartitionCount" Value="1"/>
+    <Parameter Name="CaptainHook.DirectorService_DefaultPartitionCount" Value="1"/>
+    <Parameter Name="EDA_CosmosDb_ConnectionString" Value=""/>
   </Parameters>
 </Application>

--- a/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
+++ b/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
@@ -10,6 +10,6 @@
     <Parameter Name="CaptainHook.DirectorService_DefaultTargetReplicaSetSize" Value="1"/>
     <Parameter Name="CaptainHook.DirectorService_DefaultPartitionCount" Value="1"/>
     <Parameter Name="CaptainHook.DirectorService_DefaultPartitionCount" Value="1"/>
-    <Parameter Name="EDA_CosmosDb_ConnectionString" Value=""/>
+    <Parameter Name="CosmosDb_Tooling_ConnectionString" Value=""/>
   </Parameters>
 </Application>


### PR DESCRIPTION
### What
Configure CosmosDB via Environment variables.

### Why
Temporarily we want to use Env variables to configure connection string to CosmosDB since the local emulator will be used. Long term, an Azure instance will be used and configured through KeyVaults. The run of the code is disabled until a feature flag is introduced.