### PR TITLE
Story 57196 feature flags

### DIFF
--- a/src/CaptainHook.Common/CaptainHook.Common.csproj
+++ b/src/CaptainHook.Common/CaptainHook.Common.csproj
@@ -17,4 +17,10 @@
     <PackageReference Include="IdentityModel" Version="3.10.10" />
     <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.4.677" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>CaptainHook.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/CaptainHook.Common/Configuration/FeatureFlags/CosmosDbFeatureFlag.cs
+++ b/src/CaptainHook.Common/Configuration/FeatureFlags/CosmosDbFeatureFlag.cs
@@ -1,0 +1,9 @@
+﻿namespace CaptainHook.Common.Configuration.FeatureFlags
+{
+    public class CosmosDbFeatureFlag: FeatureFlagBase
+    {
+        public CosmosDbFeatureFlag(): base("CosmosDb")
+        {
+        }
+    }
+}

--- a/src/CaptainHook.Common/Configuration/FeatureFlags/FeatureFlagBase.cs
+++ b/src/CaptainHook.Common/Configuration/FeatureFlags/FeatureFlagBase.cs
@@ -1,0 +1,16 @@
+﻿namespace CaptainHook.Common.Configuration.FeatureFlags
+{
+    public abstract class FeatureFlagBase
+    {
+        protected FeatureFlagBase(string identifier)
+        {
+            Identifier = identifier;
+        }
+
+        public string Identifier { get; }
+
+        public bool IsEnabled { get; private set; }
+
+        internal void SetEnabled(bool isEnabled) => this.IsEnabled = isEnabled;
+    }
+}

--- a/src/CaptainHook.Common/Configuration/FeatureFlagsConfiguration.cs
+++ b/src/CaptainHook.Common/Configuration/FeatureFlagsConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CaptainHook.Common.Configuration.FeatureFlags;
+using JetBrains.Annotations;
+
+namespace CaptainHook.Common.Configuration
+{
+    public class FeatureFlagsConfiguration
+    {
+        [UsedImplicitly]
+        public ICollection<string> FeatureFlags { get; } = new List<string>();
+
+        public T GetFlag<T>() where T: FeatureFlagBase, new()
+        {
+            var disabledFlag = new T();
+            
+            var flag = this.FeatureFlags
+                .FirstOrDefault(f => string.Equals(disabledFlag.Identifier, f, StringComparison.OrdinalIgnoreCase));
+            var isFlagEnabled = !string.IsNullOrEmpty(flag);
+            disabledFlag.SetEnabled(isFlagEnabled);
+
+            return disabledFlag;
+        }
+    }
+}

--- a/src/CaptainHook.DirectorService/Program.cs
+++ b/src/CaptainHook.DirectorService/Program.cs
@@ -54,12 +54,6 @@ namespace CaptainHook.DirectorService
 
                 builder.RegisterInstance(config.GetSection("event").Get<IEnumerable<EventHandlerConfig>>());
 
-                // CosmosDB support is under development
-                if (false)
-                {
-                    builder.ConfigureCosmosDb(config);
-                }
-
                 builder.RegisterInstance(settings)
                        .SingleInstance();
 
@@ -69,23 +63,10 @@ namespace CaptainHook.DirectorService
                 builder.RegisterType<FabricClient>().SingleInstance();
 
                 var featureFlags = ConfigureFeatureFlags(config, builder);
-                //if (featureFlags.GetFlag<CosmosDbFeatureFlag>().IsEnabled)
-                //{
-                //    // do something
-                //}
-
-                //todo cosmos config and rules stuff - come back to this later
-                // - we need to ensure rules which are in the db are created
-                // - rules which are updated are updated in the handlers and dispatchers
-                // - rules which are deleted can only be soft deleted - cosmos change feed does not support hard deletes
-                //var cosmosClient = new CosmosClient(settings.CosmosConnectionString);
-                //builder.RegisterInstance(cosmosClient);
-
-                //var database = (await cosmosClient.Databases.CreateDatabaseIfNotExistsAsync("captain-hook", 400)).Database;
-                //builder.RegisterInstance(database);
-
-                //var ruleContainer = (await database.Containers.CreateContainerIfNotExistsAsync(nameof(RoutingRule), RoutingRule.PartitionKeyPath)).Container;
-                //builder.RegisterInstance(ruleContainer).SingleInstance();
+                if (featureFlags.GetFlag<CosmosDbFeatureFlag>().IsEnabled)
+                {
+                    builder.ConfigureCosmosDb(config);
+                }
 
                 builder.SetupFullTelemetry(settings.InstrumentationKey);
                 builder.RegisterStatefulService<DirectorService>(ServiceNaming.DirectorServiceType);

--- a/src/Tests/CaptainHook.Tests/Configuration/FeatureFlags/CosmosDbFeatureFlagTests.cs
+++ b/src/Tests/CaptainHook.Tests/Configuration/FeatureFlags/CosmosDbFeatureFlagTests.cs
@@ -1,0 +1,40 @@
+﻿using CaptainHook.Common.Configuration.FeatureFlags;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace CaptainHook.Tests.Configuration.FeatureFlags
+{
+    public class CosmosDbFeatureFlagTests
+    {
+        [Fact, IsUnit]
+        public void CreatesDefaultInstance()
+        {
+            // Arrange
+            var cosmosDbFeatureFlag = new CosmosDbFeatureFlag();
+
+            // Assert
+            using (new AssertionScope())
+            {
+                cosmosDbFeatureFlag.Identifier.Should().Be("CosmosDb");
+                cosmosDbFeatureFlag.IsEnabled.Should().BeFalse("because by default features are off");
+            }
+        }
+
+        [Fact, IsUnit]
+        public void CanChangeEnabledProperty()
+        {
+            // Arrange
+            var cosmosDbFeatureFlag = new CosmosDbFeatureFlag();
+            cosmosDbFeatureFlag.SetEnabled(true);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                cosmosDbFeatureFlag.Identifier.Should().Be("CosmosDb");
+                cosmosDbFeatureFlag.IsEnabled.Should().BeTrue("because the default value has been overriden");
+            }
+        }
+    }
+}

--- a/src/Tests/CaptainHook.Tests/Configuration/FeatureFlagsConfigurationTests.cs
+++ b/src/Tests/CaptainHook.Tests/Configuration/FeatureFlagsConfigurationTests.cs
@@ -1,0 +1,70 @@
+﻿using CaptainHook.Common.Configuration;
+using CaptainHook.Common.Configuration.FeatureFlags;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace CaptainHook.Tests.Configuration
+{
+    public class FeatureFlagsConfigurationTests
+    {
+        [Fact, IsUnit]
+        public void GetFlag_NoFlagsConfigured_IsDisabled()
+        {
+            // Arrange
+            var featureFlagsConfiguration = new FeatureFlagsConfiguration();
+
+            // Act
+            var actual = featureFlagsConfiguration.GetFlag<TestFeatureFlag>();
+
+            // Assert
+            var expected = new TestFeatureFlag();
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact, IsUnit]
+        public void GetFlag_UnknownFlagConfigured_TestFeatureFlagIsDisabled()
+        {
+            // Arrange
+            var featureFlagsConfiguration = new FeatureFlagsConfiguration
+            {
+                FeatureFlags = { "dummy-ff" }
+            };
+
+            // Act
+            var actual = featureFlagsConfiguration.GetFlag<TestFeatureFlag>();
+
+            // Assert
+            var expected = new TestFeatureFlag();
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact, IsUnit]
+        public void GetFlag_TestFeatureFlagConfigured_IsEnabled()
+        {
+            // Arrange
+            var featureFlagsConfiguration = new FeatureFlagsConfiguration
+            {
+                FeatureFlags = { "test-ff" }
+            };
+
+            // Act
+            var actual = featureFlagsConfiguration.GetFlag<TestFeatureFlag>();
+
+            // Assert
+            using (new AssertionScope())
+            {
+                actual.Identifier.Should().Be("test-ff");
+                actual.IsEnabled.Should().BeTrue("because that feature flag was enabled");
+            }
+        }
+
+        private class TestFeatureFlag: FeatureFlagBase
+        {
+            public TestFeatureFlag(): base("test-ff")
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What
Simple Feature Flag functionality to enable/disable features by provided configuration.

### Why
CosmosDb configuration is going to live for now in the designated environments. We want to keep merging to master though and for that reason, we need to isolate the functionality with the use of feature flags.