### PR TITLE
#62771 - fix failing integration tests due to invalid Messaging reference

### DIFF
--- a/src/Tests/CaptainHook.Tests/CaptainHook.Tests.csproj
+++ b/src/Tests/CaptainHook.Tests/CaptainHook.Tests.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Eshopworld.Messaging" Version="2.1.2" />
     <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
     <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.3" />
     <PackageReference Include="IdentityModel" Version="4.2.0" />


### PR DESCRIPTION
### What
Reference EShopworld.Messaging package directly as it should have been from the beginning. Right now the old version of 1.1.1 is referenced causing issues in runtime for L1 tests.