### PR TITLE
62726 unit tests discrepancies fix

### DIFF
--- a/src/codecoverage.runsettings
+++ b/src/codecoverage.runsettings
@@ -11,7 +11,7 @@
     <TargetPlatform>x64</TargetPlatform>
 
     <!-- Framework35 | [Framework40] | Framework45 -->
-    <TargetFrameworkVersion>.NETCoreApp,Version=v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>.NETCoreApp,Version=v3.1</TargetFrameworkVersion>
 
   </RunConfiguration>
 

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+	"version": "3.1.102",
+    "allowPrerelease": false,
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Test fix for captain-hook after core 3.1 migration.
The second part of fix was to enable build cleanup in pipeline configuration on ADO.