### PR TITLE
#65429 - retry service bus setup when connection is dropped

### DIFF
--- a/src/CaptainHook.Common/Telemetry/Service/EventReader/ServiceBusReconnectionAttemptEvent.cs
+++ b/src/CaptainHook.Common/Telemetry/Service/EventReader/ServiceBusReconnectionAttemptEvent.cs
@@ -1,0 +1,9 @@
+﻿using Eshopworld.Core;
+
+namespace CaptainHook.Common.Telemetry.Service.EventReader
+{
+    public class ServiceBusReconnectionAttemptEvent : TelemetryEvent
+    {
+        public int RetryCount { get; set; }
+    }
+}

--- a/src/CaptainHook.Common/Telemetry/Service/EventReader/ServiceBusReconnectionAttemptEvent.cs
+++ b/src/CaptainHook.Common/Telemetry/Service/EventReader/ServiceBusReconnectionAttemptEvent.cs
@@ -5,6 +5,7 @@ namespace CaptainHook.Common.Telemetry.Service.EventReader
     public class ServiceBusReconnectionAttemptEvent : TelemetryEvent
     {
         public int RetryCount { get; set; }
-        public string FabricId { get; set; }
+        public string EventType { get; set; }
+        public string SubscriptionName { get; set; }
     }
 }

--- a/src/CaptainHook.Common/Telemetry/Service/EventReader/ServiceBusReconnectionAttemptEvent.cs
+++ b/src/CaptainHook.Common/Telemetry/Service/EventReader/ServiceBusReconnectionAttemptEvent.cs
@@ -5,5 +5,6 @@ namespace CaptainHook.Common.Telemetry.Service.EventReader
     public class ServiceBusReconnectionAttemptEvent : TelemetryEvent
     {
         public int RetryCount { get; set; }
+        public string FabricId { get; set; }
     }
 }

--- a/src/CaptainHook.EventReaderService/CaptainHook.EventReaderService.csproj
+++ b/src/CaptainHook.EventReaderService/CaptainHook.EventReaderService.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
+    <PackageReference Include="Polly" Version="7.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -64,7 +64,12 @@ namespace CaptainHook.EventReaderService
         internal ConcurrentDictionary<Guid, MessageReceiverWrapper> _messageReceivers = new ConcurrentDictionary<Guid, MessageReceiverWrapper>();
         internal MessageReceiverWrapper _activeMessageReader;
 
-        private Func<int, TimeSpan> exponentialBackoff = x => TimeSpan.FromSeconds(Math.Pow(2, x));
+        private static TimeSpan retryCeiling = TimeSpan.FromSeconds(60);
+        private readonly Func<int, TimeSpan> exponentialBackoff = x =>
+        {
+            var value = TimeSpan.FromSeconds(Math.Pow(2, x));
+            return retryCeiling > value ? retryCeiling : value;
+        };
 
         /// <summary>
         /// Default ctor used at runtime
@@ -274,7 +279,6 @@ namespace CaptainHook.EventReaderService
             }
             catch (Exception e)
             {
-                // HttpRequestException
                 BigBrother.Write(e.ToExceptionEvent());
             }
         }

--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -64,12 +64,9 @@ namespace CaptainHook.EventReaderService
         internal ConcurrentDictionary<Guid, MessageReceiverWrapper> _messageReceivers = new ConcurrentDictionary<Guid, MessageReceiverWrapper>();
         internal MessageReceiverWrapper _activeMessageReader;
 
-        private static TimeSpan retryCeiling = TimeSpan.FromSeconds(60);
-        private readonly Func<int, TimeSpan> exponentialBackoff = x =>
-        {
-            var value = TimeSpan.FromSeconds(Math.Pow(2, x));
-            return retryCeiling > value ? retryCeiling : value;
-        };
+        private static int retryCeilingSeconds = 60;
+        private readonly Func<int, TimeSpan> exponentialBackoff = x => 
+            TimeSpan.FromSeconds(Math.Clamp(Math.Pow(2, x), 0, retryCeilingSeconds));
 
         /// <summary>
         /// Default ctor used at runtime

--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -264,7 +264,8 @@ namespace CaptainHook.EventReaderService
                                     _bigBrother.Publish(new ServiceBusReconnectionAttemptEvent
                                     {
                                         RetryCount = retryCount,
-                                        FabricId = $"{this.Context.ServiceName}:{this.Context.ReplicaId}"
+                                        SubscriptionName = _initData.SubscriptionName,
+                                        EventType = _initData.EventType
                                     });
                                 }
                             ).ExecuteAsync(SetupServiceBus);


### PR DESCRIPTION
On EventReaderService.cs the catch block for the ServiceBusCommunicationException has been augmented with a retry policy on the Service Bus setup method to allow for a recovery when the connection drop lasts longer. The strategy is an exponential backoff.

A custom AI event is logged (ServiceBusReconnectionAttemptEvent) carrying the retry count so that appropriate alerting can be later set up.