### PR TITLE
#67466 - add web api to Captain Hook

### DIFF
--- a/src/CaptainHook.Api/CaptainHook.Api.cs
+++ b/src/CaptainHook.Api/CaptainHook.Api.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Fabric;
+using System.IO;
+using Autofac.Extensions.DependencyInjection;
+using Eshopworld.Web;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.ServiceFabric;
+using Microsoft.ApplicationInsights.ServiceFabric.Module;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.ServiceFabric.Services.Communication.AspNetCore;
+using Microsoft.ServiceFabric.Services.Communication.Runtime;
+using Microsoft.ServiceFabric.Services.Runtime;
+
+namespace CaptainHook.Api
+{
+    /// <summary>
+    /// The FabricRuntime creates an instance of this class for each service type instance. 
+    /// </summary>
+    internal sealed class CaptainHookApi : StatelessService
+    {
+        public CaptainHookApi(StatelessServiceContext context)
+            : base(context)
+        { }
+
+        /// <summary>
+        /// Optional override to create listeners (like tcp, http) for this service instance.
+        /// </summary>
+        /// <returns>The collection of listeners.</returns>
+        protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
+        {
+            return new[]
+            {
+                new ServiceInstanceListener(serviceContext =>
+                    new KestrelCommunicationListener(serviceContext, "ServiceEndpoint", (url, listener) =>
+                    {
+                        ServiceEventSource.Current.ServiceMessage(serviceContext, $"Starting Kestrel on {url}");
+
+                        return new WebHostBuilder()
+                                    .UseKestrel()
+                                    .ConfigureServices(
+                                        services => services
+                                            .AddAutofac()
+                                            .AddSingleton(serviceContext)
+                                            .AddSingleton<ITelemetryInitializer>((serviceProvider) => FabricTelemetryInitializerExtension.CreateFabricTelemetryInitializer(serviceContext))
+                                            .AddSingleton<ITelemetryModule>(new ServiceRemotingDependencyTrackingTelemetryModule())
+                                            .AddSingleton<ITelemetryModule>(new ServiceRemotingRequestTrackingTelemetryModule()))
+                                    .UseContentRoot(Directory.GetCurrentDirectory())
+                                    .UseStartup<Startup>()
+                                    .UseServiceFabricIntegration(listener, ServiceFabricIntegrationOptions.None)
+                                    .UseUrls(url)
+                                    .UseEswSsl(listener)
+                                    .Build();
+                    }))
+            };
+        }
+    }
+}

--- a/src/CaptainHook.Api/CaptainHook.Api.cs
+++ b/src/CaptainHook.Api/CaptainHook.Api.cs
@@ -32,7 +32,7 @@ namespace CaptainHook.Api
             return new[]
             {
                 new ServiceInstanceListener(serviceContext =>
-                    new KestrelCommunicationListener(serviceContext, "ServiceEndpoint", (url, listener) =>
+                    new KestrelCommunicationListener(serviceContext, "HttpsServiceEndpoint", (url, listener) =>
                     {
                         ServiceEventSource.Current.ServiceMessage(serviceContext, $"Starting Kestrel on {url}");
 

--- a/src/CaptainHook.Api/CaptainHook.Api.csproj
+++ b/src/CaptainHook.Api/CaptainHook.Api.csproj
@@ -1,0 +1,76 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Version>1.0$(DOTTED_BUILD_BUILDNUMBER)</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Adding in update for a sub dep until Ms fix the dep tree-->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="4.0.470" />
+    <PackageReference Include="Autofac" Version="5.1.4" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Eshopworld.DevOps" Version="5.0.1" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
+    <PackageReference Include="Eshopworld.Web" Version="4.0.1" />
+    <PackageReference Include="IdentityServer4" Version="3.1.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CaptainHook.Common\CaptainHook.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.CI.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.Development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.PREP.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.PROD.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.SAND.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.TEST.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Controllers\" />
+  </ItemGroup>
+
+  <Target Name="IncludeDocFile" BeforeTargets="PrepareForPublish">
+    <ItemGroup Condition=" '$(DocumentationFile)' != '' ">
+      <_DocumentationFile Include="$(DocumentationFile)" />
+      <ContentWithTargetPath Include="@(_DocumentationFile->'%(FullPath)')" RelativePath="%(_DocumentationFile.Identity)" TargetPath="%(_DocumentationFile.Filename)%(_DocumentationFile.Extension)" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/CaptainHook.Api/PackageRoot/Config/Settings.xml
+++ b/src/CaptainHook.Api/PackageRoot/Config/Settings.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Settings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+  <!-- Add your custom configuration sections and parameters here -->
+  <!--
+  <Section Name="MyConfigSection">
+    <Parameter Name="MyParameter" Value="Value1" />
+  </Section>
+  -->
+</Settings>

--- a/src/CaptainHook.Api/PackageRoot/ServiceManifest.xml
+++ b/src/CaptainHook.Api/PackageRoot/ServiceManifest.xml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ServiceManifest Name="CaptainHook.ApiPkg"
+                 Version="1.0.0"
+                 xmlns="http://schemas.microsoft.com/2011/01/fabric"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ServiceTypes>
+    <!-- This is the name of your ServiceType. 
+         This name must match the string used in RegisterServiceType call in Program.cs. -->
+    <StatelessServiceType ServiceTypeName="CaptainHook.ApiType" />
+  </ServiceTypes>
+
+  <!-- Code package is your service executable. -->
+  <CodePackage Name="Code" Version="1.0.0">
+    <EntryPoint>
+      <ExeHost>
+        <Program>CaptainHook.Api.exe</Program>
+        <WorkingFolder>CodePackage</WorkingFolder>
+      </ExeHost>
+    </EntryPoint>
+    <EnvironmentVariables>
+      <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="N/A" />
+      <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="Development"/>
+    </EnvironmentVariables>
+  </CodePackage>
+
+  <!-- Config package is the contents of the Config directoy under PackageRoot that contains an 
+       independently-updateable and versioned set of custom configuration settings for your service. -->
+  <ConfigPackage Name="Config" Version="1.0.0" />
+
+  <Resources>
+    <Endpoints>
+      <!-- This endpoint is used by the communication listener to obtain the port on which to 
+           listen. Please note that if your service is partitioned, this port is shared with 
+           replicas of different partitions that are placed in your code. -->
+      <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="5011" />
+      <Endpoint Protocol="https" Name="HttpsServiceEndpoint" Type="Input" Port="5010" />
+    </Endpoints>
+  </Resources>
+</ServiceManifest>

--- a/src/CaptainHook.Api/PackageRoot/ServiceManifest.xml
+++ b/src/CaptainHook.Api/PackageRoot/ServiceManifest.xml
@@ -19,7 +19,6 @@
       </ExeHost>
     </EntryPoint>
     <EnvironmentVariables>
-      <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="N/A" />
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="Development"/>
     </EnvironmentVariables>
   </CodePackage>
@@ -33,8 +32,7 @@
       <!-- This endpoint is used by the communication listener to obtain the port on which to 
            listen. Please note that if your service is partitioned, this port is shared with 
            replicas of different partitions that are placed in your code. -->
-      <Endpoint Protocol="http" Name="ServiceEndpoint" Type="Input" Port="5011" />
-      <Endpoint Protocol="https" Name="HttpsServiceEndpoint" Type="Input" Port="5010" />
+      <Endpoint Protocol="https" Name="HttpsServiceEndpoint" Type="Input" Port="24010" />
     </Endpoints>
   </Resources>
 </ServiceManifest>

--- a/src/CaptainHook.Api/Program.cs
+++ b/src/CaptainHook.Api/Program.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using Autofac.Extensions.DependencyInjection;
+using CaptainHook.Common;
+using Eshopworld.Telemetry;
+using Eshopworld.Web;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.ServiceFabric.Services.Runtime;
+
+namespace CaptainHook.Api
+{
+    internal static class Program
+    {
+        /// <summary>
+        /// This is the entry point of the service host process.
+        /// </summary>
+        private static void Main()
+        {
+            try
+            {
+                if (EnvironmentHelper.IsInFabric)
+                {
+                    // The ServiceManifest.XML file defines one or more service type names.
+                    // Registering a service maps a service type name to a .NET type.
+                    // When Service Fabric creates an instance of this service type,
+                    // an instance of the class is created in this host process.
+
+                    ServiceRuntime.RegisterServiceAsync(ServiceNaming.ApiServiceServiceType,
+                        context => new CaptainHookApi(context)).GetAwaiter().GetResult();
+
+                    ServiceEventSource.Current.ServiceTypeRegistered(Process.GetCurrentProcess().Id, ServiceNaming.ApiServiceServiceType);
+
+                    // Prevents this host process from terminating so services keeps running. 
+                    Thread.Sleep(Timeout.Infinite);
+                }
+                else
+                {
+                    var host = Host
+                        .CreateDefaultBuilder()
+                        .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+                        .ConfigureWebHostDefaults(w => w.UseStartup<Startup>())
+                        .Build();
+
+                    host.Run();
+                }
+            }
+            catch (Exception e)
+            {
+                ServiceEventSource.Current.ServiceHostInitializationFailed(e.ToString());
+                BigBrother.Write(e);
+                throw;
+            }
+        }
+    }
+}

--- a/src/CaptainHook.Api/ServiceConfigurationOptions.cs
+++ b/src/CaptainHook.Api/ServiceConfigurationOptions.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace CaptainHook.Api
+{
+    /// <summary>
+    /// The configuration settings for this service
+    /// 
+    /// NOTE - consider moving this to DevOps
+    /// </summary>
+    public class ServiceConfigurationOptions
+    {
+        /// <summary>
+        /// The scopes to assert on the Api
+        /// </summary>
+        public List<string> RequiredScopes { get; set; }
+
+        /// <summary>
+        /// The Authority base address
+        /// </summary>
+        public string Authority { get; set; }
+
+        /// <summary>
+        /// The Api name
+        /// </summary>
+        public string ApiName { get; set; }
+
+        /// <summary>
+        /// The Api secret
+        /// </summary>
+        public string ApiSecret { get; set; }     
+
+        /// <summary>
+        /// Indicates if the service should require https
+        /// </summary>
+        public bool IsHttps => !string.IsNullOrWhiteSpace(Authority) && Authority.StartsWith("https");
+    }
+}

--- a/src/CaptainHook.Api/ServiceEventSource.cs
+++ b/src/CaptainHook.Api/ServiceEventSource.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Diagnostics.Tracing;
+using System.Fabric;
+using System.Threading.Tasks;
+
+namespace CaptainHook.Api
+{
+    [EventSource(Name = "ESW-CaptainHook.Api")]
+    internal sealed class ServiceEventSource : EventSource
+    {
+        public static readonly ServiceEventSource Current = new ServiceEventSource();
+
+        static ServiceEventSource()
+        {
+            // A workaround for the problem where ETW activities do not get tracked until Tasks infrastructure is initialized.
+            // This problem will be fixed in .NET Framework 4.6.2.
+            Task.Run(() => { });
+        }
+
+        // Instance constructor is private to enforce singleton semantics
+        private ServiceEventSource() { }
+
+        #region Keywords
+        // Event keywords can be used to categorize events. 
+        // Each keyword is a bit flag. A single event can be associated with multiple keywords (via EventAttribute.Keywords property).
+        // Keywords must be defined as a public class named 'Keywords' inside EventSource that uses them.
+        public static class Keywords
+        {
+            public const EventKeywords Requests = (EventKeywords)0x1L;
+            public const EventKeywords ServiceInitialization = (EventKeywords)0x2L;
+        }
+        #endregion
+
+        #region Events
+        // Define an instance method for each event you want to record and apply an [Event] attribute to it.
+        // The method name is the name of the event.
+        // Pass any parameters you want to record with the event (only primitive integer types, DateTime, Guid & string are allowed).
+        // Each event method implementation should check whether the event source is enabled, and if it is, call WriteEvent() method to raise the event.
+        // The number and types of arguments passed to every event method must exactly match what is passed to WriteEvent().
+        // Put [NonEvent] attribute on all methods that do not define an event.
+        // For more information see https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventsource.aspx
+
+        [NonEvent]
+        public void Message(string message, params object[] args)
+        {
+            if (IsEnabled())
+            {
+                string finalMessage = string.Format(message, args);
+                Message(finalMessage);
+            }
+        }
+
+        private const int MessageEventId = 1;
+        [Event(MessageEventId, Level = EventLevel.Informational, Message = "{0}")]
+        public void Message(string message)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(MessageEventId, message);
+            }
+        }
+
+        [NonEvent]
+        public void ServiceMessage(ServiceContext serviceContext, string message, params object[] args)
+        {
+            if (IsEnabled())
+            {
+
+                string finalMessage = string.Format(message, args);
+                ServiceMessage(
+                    serviceContext.ServiceName.ToString(),
+                    serviceContext.ServiceTypeName,
+                    GetReplicaOrInstanceId(serviceContext),
+                    serviceContext.PartitionId,
+                    serviceContext.CodePackageActivationContext.ApplicationName,
+                    serviceContext.CodePackageActivationContext.ApplicationTypeName,
+                    serviceContext.NodeContext.NodeName,
+                    finalMessage);
+            }
+        }
+
+        // For very high-frequency events it might be advantageous to raise events using WriteEventCore API.
+        // This results in more efficient parameter handling, but requires explicit allocation of EventData structure and unsafe code.
+        // To enable this code path, define UNSAFE conditional compilation symbol and turn on unsafe code support in project properties.
+        private const int ServiceMessageEventId = 2;
+        [Event(ServiceMessageEventId, Level = EventLevel.Informational, Message = "{7}")]
+        private
+        void ServiceMessage(
+            string serviceName,
+            string serviceTypeName,
+            long replicaOrInstanceId,
+            Guid partitionId,
+            string applicationName,
+            string applicationTypeName,
+            string nodeName,
+            string message)
+        {
+            WriteEvent(ServiceMessageEventId, serviceName, serviceTypeName, replicaOrInstanceId, partitionId, applicationName, applicationTypeName, nodeName, message);
+        }
+
+        private const int ServiceTypeRegisteredEventId = 3;
+        [Event(ServiceTypeRegisteredEventId, Level = EventLevel.Informational, Message = "Service host process {0} registered service type {1}", Keywords = Keywords.ServiceInitialization)]
+        public void ServiceTypeRegistered(int hostProcessId, string serviceType)
+        {
+            WriteEvent(ServiceTypeRegisteredEventId, hostProcessId, serviceType);
+        }
+
+        private const int ServiceHostInitializationFailedEventId = 4;
+        [Event(ServiceHostInitializationFailedEventId, Level = EventLevel.Error, Message = "Service host initialization failed", Keywords = Keywords.ServiceInitialization)]
+        public void ServiceHostInitializationFailed(string exception)
+        {
+            WriteEvent(ServiceHostInitializationFailedEventId, exception);
+        }
+
+        // A pair of events sharing the same name prefix with a "Start"/"Stop" suffix implicitly marks boundaries of an event tracing activity.
+        // These activities can be automatically picked up by debugging and profiling tools, which can compute their execution time, child activities,
+        // and other statistics.
+        private const int ServiceRequestStartEventId = 5;
+        [Event(ServiceRequestStartEventId, Level = EventLevel.Informational, Message = "Service request '{0}' started", Keywords = Keywords.Requests)]
+        public void ServiceRequestStart(string requestTypeName)
+        {
+            WriteEvent(ServiceRequestStartEventId, requestTypeName);
+        }
+
+        private const int ServiceRequestStopEventId = 6;
+        [Event(ServiceRequestStopEventId, Level = EventLevel.Informational, Message = "Service request '{0}' finished", Keywords = Keywords.Requests)]
+        public void ServiceRequestStop(string requestTypeName, string exception = "")
+        {
+            WriteEvent(ServiceRequestStopEventId, requestTypeName, exception);
+        }
+        #endregion
+
+        #region Private methods
+        private static long GetReplicaOrInstanceId(ServiceContext context)
+        {
+            StatelessServiceContext stateless = context as StatelessServiceContext;
+            if (stateless != null)
+            {
+                return stateless.InstanceId;
+            }
+
+            StatefulServiceContext stateful = context as StatefulServiceContext;
+            if (stateful != null)
+            {
+                return stateful.ReplicaId;
+            }
+
+            throw new NotSupportedException("Context type not supported.");
+        }
+        #endregion
+    }
+}

--- a/src/CaptainHook.Api/Startup.cs
+++ b/src/CaptainHook.Api/Startup.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using Eshopworld.Telemetry.Configuration;
+using Eshopworld.Telemetry.Processors;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.OpenApi.Models;
 using TelemetrySettings = Eshopworld.Telemetry.Configuration.TelemetrySettings;
@@ -51,6 +52,9 @@ namespace CaptainHook.Api
         {
             builder.RegisterInstance(_telemetrySettings).SingleInstance();
             builder.RegisterModule<TelemetryModule>();
+
+            builder.RegisterType<SuccessfulProbeFilterCriteria>()
+                .As<ITelemetryFilterCriteria>();
         }
 
         /// <summary>

--- a/src/CaptainHook.Api/Startup.cs
+++ b/src/CaptainHook.Api/Startup.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using Autofac;
+using Eshopworld.Core;
+using Eshopworld.DevOps;
+using Eshopworld.Web;
+using Eshopworld.Telemetry;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using Eshopworld.Telemetry.Configuration;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.OpenApi.Models;
+using TelemetrySettings = Eshopworld.Telemetry.Configuration.TelemetrySettings;
+
+namespace CaptainHook.Api
+{
+    /// <summary>
+    /// Startup class for ASP.NET runtime
+    /// </summary>
+    public class Startup
+    {
+        private readonly TelemetrySettings _telemetrySettings = new TelemetrySettings();
+        private readonly IBigBrother _bb;
+        private readonly IConfigurationRoot _configuration;
+        private bool UseOpenApiV2 => true;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="env">hosting environment</param>
+        public Startup(IWebHostEnvironment env)
+        {
+            _configuration = EswDevOpsSdk.BuildConfiguration(env.ContentRootPath, env.EnvironmentName);
+            _configuration.GetSection("Telemetry").Bind(_telemetrySettings);
+            _bb = BigBrother.CreateDefault(_telemetrySettings.InstrumentationKey, _telemetrySettings.InternalKey);
+        }
+
+        /// <summary>
+        /// ConfigureServices is where you register dependencies. This gets
+        /// called by the runtime before the ConfigureContainer method, below.
+        /// </summary>
+        /// <remarks>See https://docs.autofac.org/en/latest/integration/aspnetcore.html#asp-net-core-3-0-and-generic-hosting</remarks>
+        /// <param name="builder">The <see cref="ContainerBuilder"/> to configure</param>
+        public void ConfigureContainer(ContainerBuilder builder)
+        {
+            builder.RegisterInstance(_telemetrySettings).SingleInstance();
+            builder.RegisterModule<TelemetryModule>();
+        }
+
+        /// <summary>
+        /// configure services to be used by the asp.net runtime
+        /// </summary>
+        /// <param name="services">service collection</param>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            try
+            {
+                services.AddApplicationInsightsTelemetry(_telemetrySettings.InstrumentationKey);
+
+                var serviceConfiguration = new ServiceConfigurationOptions();
+                _configuration.GetSection("ServiceConfigurationOptions").Bind(serviceConfiguration);
+
+                services.AddControllers(options =>
+                {
+                    var policy = ScopePolicy.Create(serviceConfiguration.RequiredScopes.ToArray());
+
+                    var filter = EnvironmentHelper.IsInFabric ? 
+                        (IFilterMetadata) new AuthorizeFilter(policy): 
+                        new AllowAnonymousFilter();
+
+                    options.Filters.Add(filter);
+
+                }).AddNewtonsoftJson();
+                
+                services.AddApiVersioning();
+                services.AddHealthChecks();
+
+                // Get XML documentation
+                var path = Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.xml");
+
+                // If not generated throw an event but it's not going to stop the app from starting
+                if (!File.Exists(path))
+                {
+                    BigBrother.Write(new Exception("Swagger XML document has not been included in the project"));
+                }
+                else
+                {
+                    services.AddSwaggerGen(c =>
+                    {
+                        c.IncludeXmlComments(path);
+                        c.SwaggerDoc("v1", new OpenApiInfo { Version = "v1", Title = "CaptainHook.Api" });
+                        c.CustomSchemaIds(x => x.FullName);
+                        c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                        {
+                            In = ParameterLocation.Header,
+                            Description = "Please insert JWT with Bearer into field",
+                            Name = "Authorization",
+                            Type = UseOpenApiV2 ? SecuritySchemeType.ApiKey : SecuritySchemeType.Http,
+                            Scheme = "bearer",
+                            BearerFormat = "JWT",
+                        });
+
+                        c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                        {
+                            {
+                                new OpenApiSecurityScheme
+                                {
+                                    Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" },
+                                },
+                                new string[0]
+                            }
+                        });
+                    });
+                }
+
+                services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddIdentityServerAuthentication(x =>
+                {
+                    x.ApiName = serviceConfiguration.ApiName;
+                    x.ApiSecret = serviceConfiguration.ApiSecret;
+                    x.Authority = serviceConfiguration.Authority;
+                    x.RequireHttpsMetadata = serviceConfiguration.IsHttps;
+                    // To include telemetry Install-Package EShopworld.Security.Services.Telemetry -Source https://eshopworld.myget.org/F/github-dev/api/v3/index.json
+                    // See https://eshopworld.visualstudio.com/evo-core/_git/security-services-telemetry?path=%2FREADME.md&_a=preview
+                    // x.AddJwtBearerEventsTelemetry(bb); 
+                });
+            }
+            catch (Exception e)
+            {
+                _bb.Publish(e.ToExceptionEvent());
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// configure asp.net pipeline
+        /// </summary>
+        /// <param name="app">application builder</param>
+        /// <param name="env">environment</param>
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseBigBrotherExceptionHandler();
+            app.UseSwagger(o =>
+            {
+                o.RouteTemplate = "swagger/{documentName}/swagger.json";
+                o.SerializeAsV2 = UseOpenApiV2;
+            });
+            app.UseSwaggerUI(o =>
+            {
+                o.SwaggerEndpoint("v1/swagger.json", "CaptainHook.Api");
+                o.RoutePrefix = "swagger";
+            });
+
+            app.UseRouting();
+            app.UseHealthChecks("/probe");
+
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints => {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/src/CaptainHook.Api/appsettings.CI.json
+++ b/src/CaptainHook.Api/appsettings.CI.json
@@ -1,0 +1,5 @@
+﻿{
+  "ServiceConfigurationOptions": {
+    "Authority": ""
+  }
+}

--- a/src/CaptainHook.Api/appsettings.Development.json
+++ b/src/CaptainHook.Api/appsettings.Development.json
@@ -1,0 +1,13 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+  "ServiceConfigurationOptions": {
+    "Authority": ""
+  }
+}

--- a/src/CaptainHook.Api/appsettings.PREP.json
+++ b/src/CaptainHook.Api/appsettings.PREP.json
@@ -1,0 +1,5 @@
+﻿{
+  "ServiceConfigurationOptions": {
+    "Authority": ""
+  }
+}

--- a/src/CaptainHook.Api/appsettings.PROD.json
+++ b/src/CaptainHook.Api/appsettings.PROD.json
@@ -1,0 +1,5 @@
+﻿{
+  "ServiceConfigurationOptions": {
+    "Authority": ""
+  }
+}

--- a/src/CaptainHook.Api/appsettings.SAND.json
+++ b/src/CaptainHook.Api/appsettings.SAND.json
@@ -1,0 +1,5 @@
+﻿{
+  "ServiceConfigurationOptions": {
+    "Authority": ""
+  }
+}

--- a/src/CaptainHook.Api/appsettings.TEST.json
+++ b/src/CaptainHook.Api/appsettings.TEST.json
@@ -1,0 +1,5 @@
+﻿{
+  "ServiceConfigurationOptions": {
+    "Authority": ""
+  }
+}

--- a/src/CaptainHook.Api/appsettings.json
+++ b/src/CaptainHook.Api/appsettings.json
@@ -1,0 +1,20 @@
+﻿{
+  "Telemetry": {
+    "InstrumentationKey": "TBA",
+    "InternalKey": "TBA"
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "ServiceConfigurationOptions": {
+    "Authority": "",
+    "ApiName": "tooling.eda.api",
+    "RequiredScopes": [
+      "tooling.eda.api.all"
+    ],
+    "Origins": []
+  }
+}

--- a/src/CaptainHook.Common/ServiceNaming.cs
+++ b/src/CaptainHook.Common/ServiceNaming.cs
@@ -14,15 +14,16 @@ namespace CaptainHook.Common
 
         public const string DirectorServiceType = "CaptainHook.DirectorServiceType";
 
-        public const string EventDispatcherServiceName = "Dispatcher";
-
-        public const string EventDispatcherServiceType = "CaptainHook.EventDispatcherServiceType";
-
         public const string EventHandlerServiceShortName = "EventHandler";
 
         public static readonly string EventHandlerServiceFullName = $"fabric:/{CaptainHookApplication.ApplicationName}/{EventHandlerServiceShortName}";
 
         public const string EventHandlerActorServiceType = "EventHandlerActorServiceType";
 
+        public const string ApiServiceShortName = "Api";
+
+        public static readonly string ApiServiceFullName = $"fabric:/{CaptainHookApplication.ApplicationName}/{ApiServiceShortName}";
+
+        public const string ApiServiceServiceType = "CaptainHook.ApiType";
     }
 }

--- a/src/CaptainHook.Common/ServiceNaming.cs
+++ b/src/CaptainHook.Common/ServiceNaming.cs
@@ -20,10 +20,6 @@ namespace CaptainHook.Common
 
         public const string EventHandlerActorServiceType = "EventHandlerActorServiceType";
 
-        public const string ApiServiceShortName = "Api";
-
-        public static readonly string ApiServiceFullName = $"fabric:/{CaptainHookApplication.ApplicationName}/{ApiServiceShortName}";
-
         public const string ApiServiceServiceType = "CaptainHook.ApiType";
     }
 }

--- a/src/CaptainHook.DirectorService/DirectorService.cs
+++ b/src/CaptainHook.DirectorService/DirectorService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Fabric;
 using System.Fabric.Description;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Common;
@@ -71,6 +70,21 @@ namespace CaptainHook.DirectorService
                             PartitionSchemeDescription = new UniformInt64RangePartitionSchemeDescription(10),
                             ServiceTypeName = ServiceNaming.EventHandlerActorServiceType,
                             ServiceName = new Uri(ServiceNaming.EventHandlerServiceFullName),
+                            PlacementConstraints = _defaultServiceSettings.DefaultPlacementConstraints
+                        },
+                        TimeSpan.FromSeconds(30),
+                        cancellationToken);
+                }
+
+                if (!serviceList.Contains(ServiceNaming.ApiServiceFullName))
+                {
+                    await _fabricClient.ServiceManager.CreateServiceAsync(
+                        new StatelessServiceDescription
+                        {
+                            ApplicationName = new Uri($"fabric:/{Constants.CaptainHookApplication.ApplicationName}"),
+                            PartitionSchemeDescription = new UniformInt64RangePartitionSchemeDescription(1),
+                            ServiceTypeName = ServiceNaming.ApiServiceServiceType,
+                            ServiceName = new Uri(ServiceNaming.ApiServiceFullName),
                             PlacementConstraints = _defaultServiceSettings.DefaultPlacementConstraints
                         },
                         TimeSpan.FromSeconds(30),

--- a/src/CaptainHook.DirectorService/DirectorService.cs
+++ b/src/CaptainHook.DirectorService/DirectorService.cs
@@ -76,21 +76,6 @@ namespace CaptainHook.DirectorService
                         cancellationToken);
                 }
 
-                if (!serviceList.Contains(ServiceNaming.ApiServiceFullName))
-                {
-                    await _fabricClient.ServiceManager.CreateServiceAsync(
-                        new StatelessServiceDescription
-                        {
-                            ApplicationName = new Uri($"fabric:/{Constants.CaptainHookApplication.ApplicationName}"),
-                            PartitionSchemeDescription = new UniformInt64RangePartitionSchemeDescription(1),
-                            ServiceTypeName = ServiceNaming.ApiServiceServiceType,
-                            ServiceName = new Uri(ServiceNaming.ApiServiceFullName),
-                            PlacementConstraints = _defaultServiceSettings.DefaultPlacementConstraints
-                        },
-                        TimeSpan.FromSeconds(30),
-                        cancellationToken);
-                }
-
                 foreach (var (key, subscriber) in _subscriberConfigurations)
                 {
                     if (cancellationToken.IsCancellationRequested) return;

--- a/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
@@ -11,6 +11,7 @@
     <Parameter Name="CaptainHook.DirectorService_PartitionCount" DefaultValue="1" />
     <Parameter Name="CaptainHook.DirectorService_TargetReplicaSetSize" DefaultValue="3" />
     <Parameter Name="CosmosDb_Tooling_ConnectionString" DefaultValue="" />
+    <Parameter Name="CaptainHook.Api_InstanceCount" DefaultValue="1" />
   </Parameters>
   <!-- Import the ServiceManifest from the ServicePackage. The ServiceManifestName and ServiceManifestVersion 
        should match the Name and Version attributes of the ServiceManifest element defined in the 
@@ -18,7 +19,6 @@
   <ServiceManifestImport>
     <ServiceManifestRef ServiceManifestName="CaptainHook.ApiPkg" ServiceManifestVersion="1.0.0" />
     <EnvironmentOverrides CodePackageRef="Code">
-      <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="[KeyVault_Base_Uri]" />
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="[AspNetCore_Environment]" />
     </EnvironmentOverrides>
   </ServiceManifestImport>
@@ -57,6 +57,11 @@
     </EnvironmentOverrides>
   </ServiceManifestImport>
   <DefaultServices>
+    <Service Name="CaptainHook.ApiPkg" ServicePackageActivationMode="ExclusiveProcess">
+      <StatelessService ServiceTypeName="CaptainHook.ApiType" InstanceCount="[CaptainHook.Api_InstanceCount]">
+        <SingletonPartition />
+      </StatelessService>
+    </Service>
     <Service Name="CaptainHook.DirectorService" ServicePackageActivationMode="ExclusiveProcess">
       <StatefulService ServiceTypeName="CaptainHook.DirectorServiceType" TargetReplicaSetSize="[CaptainHook.DirectorService_TargetReplicaSetSize]" MinReplicaSetSize="[CaptainHook.DirectorService_MinReplicaSetSize]">
         <SingletonPartition />

--- a/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
@@ -16,6 +16,13 @@
        should match the Name and Version attributes of the ServiceManifest element defined in the 
        ServiceManifest.xml file. -->
   <ServiceManifestImport>
+    <ServiceManifestRef ServiceManifestName="CaptainHook.ApiPkg" ServiceManifestVersion="1.0.0" />
+    <EnvironmentOverrides CodePackageRef="Code">
+      <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="[KeyVault_Base_Uri]" />
+      <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="[AspNetCore_Environment]" />
+    </EnvironmentOverrides>
+  </ServiceManifestImport>
+  <ServiceManifestImport>
     <ServiceManifestRef ServiceManifestName="CaptainHook.EventHandlerActorPkg" ServiceManifestVersion="1.0.0" />
     <EnvironmentOverrides CodePackageRef="Code">
       <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="[KeyVault_Base_Uri]" />

--- a/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
+++ b/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
@@ -2,7 +2,7 @@
 <Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/CaptainHook" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="KeyVault_Base_Uri" Value="https://esw-tooling-ci-we.vault.azure.net/" />
-    <Parameter Name="AspNetCore_Environment" Value="ci" />
+    <Parameter Name="AspNetCore_Environment" Value="Development" />
     <Parameter Name="CaptainHook.DirectorService_PartitionCount" Value="1" />
     <Parameter Name="CaptainHook.DirectorService_MinReplicaSetSize" Value="1" />
     <Parameter Name="CaptainHook.DirectorService_TargetReplicaSetSize" Value="1" />

--- a/src/CaptainHook.Fabric/CaptainHook.Fabric.sfproj
+++ b/src/CaptainHook.Fabric/CaptainHook.Fabric.sfproj
@@ -41,6 +41,7 @@
     <Content Include="PublishProfiles\TEST.xml" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CaptainHook.Api\CaptainHook.Api.csproj" />
     <ProjectReference Include="..\CaptainHook.DirectorService\CaptainHook.DirectorService.csproj" />
     <ProjectReference Include="..\CaptainHook.EventHandlerActor\CaptainHook.EventHandlerActor.csproj" />
     <ProjectReference Include="..\CaptainHook.EventReaderService\CaptainHook.EventReaderService.csproj" />

--- a/src/CaptainHook.sln
+++ b/src/CaptainHook.sln
@@ -34,7 +34,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CaptainHook.Telemetry.Tests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CaptainHook.Cli", "CaptainHook.Cli\CaptainHook.Cli.csproj", "{A164B0E1-58EA-4F96-BE08-900AC00609F7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CaptainHook.Cli.Tests", "CaptainHook.Cli.Tests\CaptainHook.Cli.Tests.csproj", "{60D82264-1246-4205-A704-EF8A290A9A4D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CaptainHook.Cli.Tests", "CaptainHook.Cli.Tests\CaptainHook.Cli.Tests.csproj", "{60D82264-1246-4205-A704-EF8A290A9A4D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CaptainHook.Api", "CaptainHook.Api\CaptainHook.Api.csproj", "{DE1559AF-7CF2-4196-9F83-2C272D7357D0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -136,6 +138,14 @@ Global
 		{60D82264-1246-4205-A704-EF8A290A9A4D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{60D82264-1246-4205-A704-EF8A290A9A4D}.Release|x64.ActiveCfg = Release|Any CPU
 		{60D82264-1246-4205-A704-EF8A290A9A4D}.Release|x64.Build.0 = Release|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE1559AF-7CF2-4196-9F83-2C272D7357D0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### What
Changes which add Web Api to Captain Hook and host it within Service Fabric. The Api supports /probe endpoint only at this stage.

### Why
The Web API is going to be used to control Captain Hook configuration in the long term.

### Proof of life
![image](https://user-images.githubusercontent.com/60343978/81949837-9067a000-9603-11ea-87f7-e8f288d2c92a.png)
