### PR TITLE
#67475 - establish remoting betwen API and Director Service

### DIFF
--- a/src/CaptainHook.Api/Controllers/RefreshConfigController.cs
+++ b/src/CaptainHook.Api/Controllers/RefreshConfigController.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using CaptainHook.Api.Models;
+using CaptainHook.Common;
+using CaptainHook.Common.Remoting;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.ServiceFabric.Services.Remoting.Client;
+
+namespace CaptainHook.Api.Controllers
+{
+    /// <summary>
+    /// Refresh configuration controller
+    /// </summary>
+    [Route("api/refresh-config")]
+    [AllowAnonymous]
+    public class RefreshConfigController: Controller
+    {
+        /// <summary>
+        /// Refreshes configuration for the given event
+        /// </summary>
+        /// <param name="request">Request with details to refresh configuration</param>
+        /// <returns>If the event name is valid, returns its configuration. If invalid, returns BadRequest</returns>
+        [HttpPost]
+        public async Task<IActionResult> RefreshConfigForEvent([FromBody]RefreshConfigRequest request)
+        {
+            try
+            {
+                var directorServiceClient = ServiceProxy.Create<IDirectorServiceRemoting>(new Uri(ServiceNaming.DirectorServiceFullName));
+                var refreshedSubscribersCount = await directorServiceClient.GetConfigurationForEventAsync(request.EventName);
+                if (refreshedSubscribersCount > 0)
+                {
+                    return Ok(refreshedSubscribersCount);
+                }
+
+                return BadRequest($"Event {request.EventName} does not exist in the configuration");
+            }
+            catch
+            {
+                return BadRequest();
+            }
+        }
+    }
+}

--- a/src/CaptainHook.Api/Models/RefreshConfigRequest.cs
+++ b/src/CaptainHook.Api/Models/RefreshConfigRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace CaptainHook.Api.Models
+{
+    public class RefreshConfigRequest
+    {
+        public string EventName { get; set; }
+    }
+}

--- a/src/CaptainHook.Common/Remoting/IDirectorServiceRemoting.cs
+++ b/src/CaptainHook.Common/Remoting/IDirectorServiceRemoting.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Microsoft.ServiceFabric.Services.Remoting;
+
+namespace CaptainHook.Common.Remoting
+{
+    public interface IDirectorServiceRemoting: IService
+    {
+        Task<int> GetConfigurationForEventAsync(string eventName);
+    }
+}

--- a/src/CaptainHook.Common/ServiceNaming.cs
+++ b/src/CaptainHook.Common/ServiceNaming.cs
@@ -18,6 +18,8 @@ namespace CaptainHook.Common
 
         public static readonly string EventHandlerServiceFullName = $"fabric:/{CaptainHookApplication.ApplicationName}/{EventHandlerServiceShortName}";
 
+        public static readonly string DirectorServiceFullName = $"fabric:/{CaptainHookApplication.ApplicationName}/CaptainHook.DirectorService";
+
         public const string EventHandlerActorServiceType = "EventHandlerActorServiceType";
 
         public const string ApiServiceServiceType = "CaptainHook.ApiType";

--- a/src/CaptainHook.DirectorService/DirectorService.cs
+++ b/src/CaptainHook.DirectorService/DirectorService.cs
@@ -7,13 +7,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Common;
 using CaptainHook.Common.Configuration;
+using CaptainHook.Common.Remoting;
 using CaptainHook.Common.ServiceModels;
 using Eshopworld.Core;
+using Microsoft.ServiceFabric.Services.Communication.Runtime;
+using Microsoft.ServiceFabric.Services.Remoting.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
 
 namespace CaptainHook.DirectorService
 {
-    public class DirectorService : StatefulService
+    public class DirectorService : StatefulService, IDirectorServiceRemoting
     {
         private readonly IBigBrother _bigBrother;
         private readonly FabricClient _fabricClient;
@@ -139,6 +142,18 @@ namespace CaptainHook.DirectorService
                 _bigBrother.Publish(ex.ToExceptionEvent());
                 throw;
             }
+        }
+
+        public Task<int> GetConfigurationForEventAsync(string eventName)
+        {
+            var subscribersForEvent =
+                _subscriberConfigurations.Keys.Count(k => k.StartsWith(eventName, StringComparison.OrdinalIgnoreCase));
+            return Task.FromResult(subscribersForEvent);
+        }
+
+        protected override IEnumerable<ServiceReplicaListener> CreateServiceReplicaListeners()
+        {
+            return this.CreateServiceRemotingReplicaListeners();
         }
     }
 }


### PR DESCRIPTION
### What
A simple controller along with the remoting service client are set up to demonstrate the communication between two components.

### Why
The current implementation takes the event name and as an example returns the counter of configurations of valid subscribers to that event that are found in Director Service. This logic can be extended now that the base is ready.

### Proof of life
![image](https://user-images.githubusercontent.com/60343978/82323895-02136580-99d9-11ea-85df-9f6e5949897e.png)
