### PR TITLE
Remove conditional compilation for auth mode

### DIFF
--- a/src/CaptainHook.Api/CaptainHook.Api.csproj
+++ b/src/CaptainHook.Api/CaptainHook.Api.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;OAUTH_OFF_MODE</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### What 
Removes a conditional compilation constant that allows to bypass authentication when in debug mode. The reason why this was originally brought in is because this is the same approach used in Bullfrog and it seemed reasonable for consistency.

### Why
The pipeline is currently building and releasing in debug mode so authentication won't be enabled. We clearly don't want this.