### PR TITLE
Task 70711 graceful shutdown

### DIFF
--- a/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
+++ b/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CaptainHook.Common\CaptainHook.Common.csproj" />
     <ProjectReference Include="..\CaptainHook.Database\CaptainHook.Database.csproj" />
+    <ProjectReference Include="..\CaptainHook.Interfaces\CaptainHook.Interfaces.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CaptainHook.EventReaderService/Events/GracefulShutdownCompletedForReaderEvent.cs
+++ b/src/CaptainHook.EventReaderService/Events/GracefulShutdownCompletedForReaderEvent.cs
@@ -1,0 +1,17 @@
+﻿using Eshopworld.Core;
+
+namespace CaptainHook.EventReaderService.Events
+{
+    public class GracefulShutdownCompletedForReaderEvent: TimedTelemetryEvent
+    {
+        public GracefulShutdownCompletedForReaderEvent(string readerName, string eventType)
+        {
+            ReaderName = readerName;
+            EventType = eventType;
+        }
+
+        public string ReaderName { get; }
+
+        public string EventType { get; }
+    }
+}

--- a/src/CaptainHook.EventReaderService/Events/GracefulShutdownRequestedForReaderEvent.cs
+++ b/src/CaptainHook.EventReaderService/Events/GracefulShutdownRequestedForReaderEvent.cs
@@ -1,0 +1,17 @@
+﻿using Eshopworld.Core;
+
+namespace CaptainHook.EventReaderService.Events
+{
+    public class GracefulShutdownRequestedForReaderEvent: TelemetryEvent
+    {
+        public GracefulShutdownRequestedForReaderEvent(string readerName, string eventType)
+        {
+            ReaderName = readerName;
+            EventType = eventType;
+        }
+
+        public string ReaderName { get; }
+
+        public string EventType { get; }
+    }
+}

--- a/src/CaptainHook.EventReaderService/Events/ServiceDeletedEvent.cs
+++ b/src/CaptainHook.EventReaderService/Events/ServiceDeletedEvent.cs
@@ -1,0 +1,14 @@
+﻿using Eshopworld.Core;
+
+namespace CaptainHook.EventReaderService.Events
+{
+    class ServiceDeletedEvent : TelemetryEvent
+    {
+        public string ReaderName { get; }
+
+        public ServiceDeletedEvent(string readerName)
+        {
+            ReaderName = readerName;
+        }
+    }
+}

--- a/src/CaptainHook.EventReaderService/Program.cs
+++ b/src/CaptainHook.EventReaderService/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Fabric;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
@@ -29,6 +30,8 @@ namespace CaptainHook.EventReaderService
                 builder.RegisterInstance(configurationSettings).SingleInstance();
                 builder.RegisterType<MessageProviderFactory>().As<IMessageProviderFactory>().SingleInstance();
                 builder.RegisterType<ServiceBusManager>().As<IServiceBusManager>();
+                builder.RegisterType<FabricClient>()
+                    .SingleInstance();
 
                 //SF Deps
                 builder.Register<IActorProxyFactory>(_ => new ActorProxyFactory());

--- a/src/CaptainHook.Interfaces/IEventReaderService.cs
+++ b/src/CaptainHook.Interfaces/IEventReaderService.cs
@@ -15,5 +15,7 @@ namespace CaptainHook.Interfaces
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task CompleteMessageAsync(MessageData messageData, bool messageDelivered, CancellationToken cancellationToken = default);
+
+        Task InitializeGracefulShutdown(string directorServiceName);
     }
 }

--- a/src/CaptainHook.Interfaces/IEventReaderService.cs
+++ b/src/CaptainHook.Interfaces/IEventReaderService.cs
@@ -16,6 +16,6 @@ namespace CaptainHook.Interfaces
         /// <returns></returns>
         Task CompleteMessageAsync(MessageData messageData, bool messageDelivered, CancellationToken cancellationToken = default);
 
-        Task InitializeGracefulShutdown(string directorServiceName);
+        Task InitializeGracefulShutdown();
     }
 }


### PR DESCRIPTION
### What
Ensure all messages have been processed before the source reader (for the message) is deleted.

### How

1. Director service informs Reader service of the intent to gracefully shut down
2. Reader service stops retrieving new messages and awaits the Event Handler to inform on message processing completion
3. Reader service identifies the final message has been processed and initiates self-delete

### Testing method
When testing I have been constantly sending messages in the background and changing the config of a webhook. I would set it to target endpoint A and use API to reload config. Then after a few seconds, I would change the setting to target endpoint B and use API to reload config.

### Problems
Quite often the sum of processed and delivered messages is greater than the sum of generated messages and pushed to Service Bus. They are never lower, which is good. However, some messages can be delivered twice and at the moment I cannot pinpoint it to the area in the code. If you could take a look, maybe you can spot something.