### PR TITLE
#72356 - add reader heart beat

### DIFF
--- a/src/CaptainHook.Cli.Tests/GenerateJson/EventTests.cs
+++ b/src/CaptainHook.Cli.Tests/GenerateJson/EventTests.cs
@@ -48,5 +48,14 @@ namespace CaptainHook.Cli.Tests.GenerateJson
             JsonResult["CallbackConfig"]
                 .Should().BeOfType<JObject>();
         }
+
+        [Fact, IsLayer0]
+        public async Task SupportsHeartBeatConfig()
+        {
+            PrepareCommand();
+            await Command.OnExecuteAsync(Application, Console);
+            JsonResult["HeartBeatInterval"]
+                .Should().BeOfType<JValue>().Which.Value<string>().Should().Be("00:00:05");
+        }
     }
 }

--- a/src/CaptainHook.Cli.Tests/GeneratePowerShell/ConfigDirectoryProcessorTests.cs
+++ b/src/CaptainHook.Cli.Tests/GeneratePowerShell/ConfigDirectoryProcessorTests.cs
@@ -17,7 +17,8 @@ namespace CaptainHook.Cli.Tests.GeneratePowerShell
             fileSystem.AddFile(@"C:\Test\event-10-testevent.json", $"{{\r\n\"Type\": \"type10\" \r\n}}");
             fileSystem.AddFile(@"C:\Test\event-11-testevent.json", $"{{\r\n\"Type\": \"type11\" \r\n}}");
             fileSystem.AddFile(@"C:\Test\event-101-testevent.json", $"{{\r\n\"Type\": \"type101\" \r\n}}");
-            fileSystem.AddFile(@"C:\Test\event-2-testevent.json", $"{{\r\n\"Type\": \"type2\" \r\n}}");
+            fileSystem.AddFile(@"C:\Test\event-2-testevent.json", $"{{\r\n\"Type\": \"type2\",\r\n\"HeartBeatInterval\":\"\" \r\n}}");
+            fileSystem.AddFile(@"C:\Test\event-3-testevent.json", $"{{\r\n\"Type\": \"type3\",\r\n\"HeartBeatInterval\":\"00:00:05\" \r\n}}");
 
         }
 
@@ -28,6 +29,9 @@ namespace CaptainHook.Cli.Tests.GeneratePowerShell
             {
                 "setConfig 'event--1--type' 'type1' $KeyVault",
                 "setConfig 'event--2--type' 'type2' $KeyVault",
+                "setConfig 'event--2--heartbeatinterval' '' $KeyVault",
+                "setConfig 'event--3--type' 'type3' $KeyVault",
+                "setConfig 'event--3--heartbeatinterval' '00:00:05' $KeyVault",
                 "setConfig 'event--10--type' 'type10' $KeyVault",
                 "setConfig 'event--11--type' 'type11' $KeyVault",
                 "setConfig 'event--101--type' 'type101' $KeyVault",
@@ -54,6 +58,9 @@ namespace CaptainHook.Cli.Tests.GeneratePowerShell
                 "def from header",
                 "setConfig 'event--1--type' 'type1' $KeyVault",
                 "setConfig 'event--2--type' 'type2' $KeyVault",
+                "setConfig 'event--2--heartbeatinterval' '' $KeyVault",
+                "setConfig 'event--3--type' 'type3' $KeyVault",
+                "setConfig 'event--3--heartbeatinterval' '00:00:05' $KeyVault",
                 "setConfig 'event--10--type' 'type10' $KeyVault",
                 "setConfig 'event--11--type' 'type11' $KeyVault",
                 "setConfig 'event--101--type' 'type101' $KeyVault",

--- a/src/CaptainHook.Cli.Tests/SampleFile.ps1
+++ b/src/CaptainHook.Cli.Tests/SampleFile.ps1
@@ -46,6 +46,8 @@ setConfig 'CaptainHook--RequiredScopes--1' 'aaa.bbb.ccc' $KeyVault
 #First Domain Event 
 setConfig 'event--1--type' 'activity1.domain.infrastructure.domainevents.activityconfirmationdomainevent' $KeyVault
 setConfig 'event--1--name' 'activity1.domain.infrastructure.domainevents.activityconfirmationdomainevent' $KeyVault
+setConfig 'event--1--heartbeatinterval' '00:00:05' $KeyVault
+
 setConfig 'event--1--webhookconfig--name' 'activity1.domain.infrastructure.domainevents.activityconfirmationdomainevent-webhook' $KeyVault
 setConfig 'event--1--webhookconfig--uri' 'https://ct.site.com/api/v1/WebHook/Update' $KeyVault
 setConfig 'event--1--webhookconfig--authenticationconfig--type' 2 $KeyVault

--- a/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
+++ b/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
@@ -157,12 +157,18 @@ namespace CaptainHook.Common.Configuration
         public bool IsMainConfiguration { get; private set; }
 
         /// <summary>
+        /// Provide this value as TimeSpan format to send HeartBeat telemetry event from Event Reader
+        /// </summary>
+        public string HeartBeatInterval { get; set; }
+
+        /// <summary>
         /// Tranforms the old structure of configuration into the new one.
         /// </summary>
         /// <param name="webhookConfig">The webhook configuration.</param>
         /// <param name="callback">The callback associated with <paramref name="webhookConfig"/>.</param>
+        /// <param name="heartBeatInterval">Heart Beat Interval value if applicable.</param>
         /// <returns>The subscriber configuration consisting of the webhook configuration and its callback.</returns>
-        public static SubscriberConfiguration FromWebhookConfig(WebhookConfig webhookConfig, WebhookConfig callback)
+        public static SubscriberConfiguration FromWebhookConfig(WebhookConfig webhookConfig, WebhookConfig callback, string heartBeatInterval)
         {
             return new SubscriberConfiguration
             {
@@ -177,6 +183,7 @@ namespace CaptainHook.Common.Configuration
                 WebhookRequestRules = webhookConfig.WebhookRequestRules,
                 Callback = callback,
                 IsMainConfiguration = true,
+                HeartBeatInterval = heartBeatInterval
             };
         }
 
@@ -209,7 +216,7 @@ namespace CaptainHook.Common.Configuration
         /// <summary>
         /// The list of all subscibers of the topic handling the event type.
         /// </summary>
-        [JsonProperty(Order = 5)]
+        [JsonProperty(Order = 6)]
         public List<SubscriberConfiguration> Subscribers { get; } = new List<SubscriberConfiguration>();
 
         /// <summary>
@@ -221,7 +228,7 @@ namespace CaptainHook.Common.Configuration
             get
             {
                 if (WebhookConfig != null)
-                    yield return SubscriberConfiguration.FromWebhookConfig(WebhookConfig, CallbackConfig);
+                    yield return SubscriberConfiguration.FromWebhookConfig(WebhookConfig, CallbackConfig, HeartBeatInterval);
                 foreach (var conf in Subscribers)
                 {
                     conf.CollectionIndex = Subscribers.IndexOf(conf);
@@ -247,6 +254,9 @@ namespace CaptainHook.Common.Configuration
 
         [JsonProperty(Order = 1)]
         public string Type { get; set; }
+
+        [JsonProperty(Order = 5)]
+        public string HeartBeatInterval { get; set; }
     }
 
     public class WebhookRequestRule

--- a/src/CaptainHook.Common/ServiceModels/EventReaderInitData.cs
+++ b/src/CaptainHook.Common/ServiceModels/EventReaderInitData.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Text;
 using CaptainHook.Common.Configuration;
 using CaptainHook.Common.Json;
@@ -24,6 +25,8 @@ namespace CaptainHook.Common.ServiceModels
 
         public string SubscriptionName => DlqMode != null ? SourceSubscription : SubscriberName;
 
+        public TimeSpan? HeartBeatInterval { get; set; }
+
         private static JsonIgnoreAttributeIgnorerContractResolver jsonIgnoreAttributeIgnorerContractResolver = new JsonIgnoreAttributeIgnorerContractResolver();
 
         private static AuthenticationConfigConverter authenticationConfigConverter = new AuthenticationConfigConverter();
@@ -37,7 +40,8 @@ namespace CaptainHook.Common.ServiceModels
                 EventType = subscriberConfiguration.EventType,
                 DlqMode = subscriberConfiguration.DLQMode,
                 SourceSubscription = subscriberConfiguration.DLQMode != null ? subscriberConfiguration.SourceSubscriptionName : null,
-                WebhookConfig = webhookConfig
+                WebhookConfig = webhookConfig,
+                HeartBeatInterval = TimeSpan.TryParse(subscriberConfiguration.HeartBeatInterval, out var heartBeatInterval) ? heartBeatInterval : (TimeSpan?)null
             };
         }
 

--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -151,8 +151,14 @@ namespace CaptainHook.EventReaderService
         protected override async Task OnOpenAsync(ReplicaOpenMode openMode, CancellationToken cancellationToken)
         {
             _bigBrother.Publish(new ServiceActivatedEvent(Context, InFlightMessageCount));
-            _heartBeatTimer = new Timer(HeartBeatTimerCallback, null, TimeSpan.FromSeconds(1.0), TimeSpan.FromSeconds(10.0));
-            _heartBeatStats = new HeartBeatStats(true);
+
+            var heartBeatEnabled = _initData.HeartBeatInterval != null;
+            _heartBeatStats = new HeartBeatStats(heartBeatEnabled);
+            if (heartBeatEnabled)
+            {
+                _heartBeatTimer = new Timer(HeartBeatTimerCallback, null, TimeSpan.FromSeconds(1.0), _initData.HeartBeatInterval.Value);
+            }
+
             await base.OnOpenAsync(openMode, cancellationToken);
         }
 

--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -424,6 +424,7 @@ namespace CaptainHook.EventReaderService
             finally
             {
                 _freeHandlers.Enqueue(messageData.HandlerId);
+                _heartBeatStats.ReportCompleteMessage(messageDelivered);
             }
         }
     }

--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -14,6 +14,7 @@ using CaptainHook.Common.Configuration;
 using CaptainHook.Common.ServiceModels;
 using CaptainHook.Common.Telemetry.Service;
 using CaptainHook.Common.Telemetry.Service.EventReader;
+using CaptainHook.EventReaderService.HeartBeat;
 using CaptainHook.Interfaces;
 using Eshopworld.Core;
 using Eshopworld.Telemetry;
@@ -64,6 +65,10 @@ namespace CaptainHook.EventReaderService
         private static int retryCeilingSeconds = 60;
         private readonly Func<int, TimeSpan> exponentialBackoff = x =>
             TimeSpan.FromSeconds(Math.Clamp(Math.Pow(2, x), 0, retryCeilingSeconds));
+
+        private Timer _heartBeatTimer;
+
+        private HeartBeatStats _heartBeatStats;
 
         /// <summary>
         /// Default ctor used at runtime
@@ -146,11 +151,24 @@ namespace CaptainHook.EventReaderService
         protected override async Task OnOpenAsync(ReplicaOpenMode openMode, CancellationToken cancellationToken)
         {
             _bigBrother.Publish(new ServiceActivatedEvent(Context, InFlightMessageCount));
+            _heartBeatTimer = new Timer(HeartBeatTimerCallback, null, TimeSpan.FromSeconds(1.0), TimeSpan.FromSeconds(10.0));
+            _heartBeatStats = new HeartBeatStats(true);
             await base.OnOpenAsync(openMode, cancellationToken);
+        }
+
+        private void HeartBeatTimerCallback(object state)
+        {
+            // when the app is starting and there are no handlers in action we discover this situation
+            var handlerCount = _freeHandlers.Count == 0 && HandlerCount == 10 ? 0 : HandlerCount;
+            _heartBeatStats.ReportInFlight(_inflightMessages.Count, handlerCount);
+            var heartBeatEvent = _heartBeatStats.ToTelemetryEvent(Context);
+
+            _bigBrother.Publish(heartBeatEvent);
         }
 
         protected override async Task OnCloseAsync(CancellationToken cancellationToken)
         {
+            _heartBeatTimer.Dispose();
             _bigBrother.Publish(new ServiceDeactivatedEvent(Context, InFlightMessageCount));
             await base.OnCloseAsync(cancellationToken);
         }
@@ -212,9 +230,12 @@ namespace CaptainHook.EventReaderService
 
                         var (messages, activeReaderId) = await ReceiveMessagesFromActiveReceiver();
 
+                        var readMessages = messages?.Count ?? 0;
+                        _heartBeatStats.ReportMessagesRead(readMessages);
+
                         await ServiceReceiversLifecycle();
 
-                        if (messages == null || messages.Count == 0)
+                        if (readMessages == 0)
                         {
                             // ReSharper disable once MethodSupportsCancellation - no need to cancellation token here
 #if DEBUG

--- a/src/CaptainHook.EventReaderService/HeartBeat/HeartBeatStats.cs
+++ b/src/CaptainHook.EventReaderService/HeartBeat/HeartBeatStats.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Fabric;
+
+namespace CaptainHook.EventReaderService.HeartBeat
+{
+    public class HeartBeatStats
+    {
+        private readonly object _syncObject = new object();
+
+        private int _numberOfMessagesInFlight;
+
+        private int _numberOfAvailableHandlers;
+
+        private DateTime? _lastTimeMessagesReadUtc;
+
+        private int _numberOfMessagesReadLastTime;
+
+        private int _numberOfMessagesReadSinceLastHeartBeat;
+
+        private int _numberOfTimesNoMessagesReadSinceLastHeartBeat;
+
+        private readonly bool _enabled;
+
+        public HeartBeatStats(bool enabled)
+        {
+            _enabled = enabled;
+        }
+
+        public void ReportMessagesRead(int numberOfMessagesRead)
+        {
+            if (!_enabled)
+            {
+                return;
+            }
+
+            lock (_syncObject)
+            {
+                _lastTimeMessagesReadUtc = DateTime.UtcNow;
+                _numberOfMessagesReadLastTime = numberOfMessagesRead;
+
+                _numberOfMessagesReadSinceLastHeartBeat += numberOfMessagesRead;
+                if (numberOfMessagesRead == 0)
+                {
+                    _numberOfTimesNoMessagesReadSinceLastHeartBeat++;
+                }
+            }
+        }
+
+
+        public void ReportInFlight(int inflightMessagesCount, int handlerCount)
+        {
+            if (!_enabled)
+            {
+                return;
+            }
+
+            lock (_syncObject)
+            {
+                _numberOfMessagesInFlight = inflightMessagesCount;
+                _numberOfAvailableHandlers = handlerCount;
+            }
+        }
+
+        public ReaderHeartBeatEvent ToTelemetryEvent(StatefulServiceContext context)
+        {
+            if (!_enabled)
+            {
+                throw new NotSupportedException($"Heart Beat monitoring is disabled for service: {context.ServiceName}");
+            }
+
+            lock (_syncObject)
+            {
+                var telemetryEvent = new ReaderHeartBeatEvent(context)
+                {
+                    NumberOfMessagesInFlight = _numberOfMessagesInFlight,
+                    NumberOfAvailableHandlers = _numberOfAvailableHandlers,
+                    LastTimeMessagesReadUtc = _lastTimeMessagesReadUtc,
+                    NumberOfMessagesReadLastTime = _numberOfMessagesReadLastTime,
+                    NumberOfTimesNoMessagesReadSinceLastHeartBeat = _numberOfTimesNoMessagesReadSinceLastHeartBeat,
+                    NumberOfMessagesReadSinceLastHeartBeat = _numberOfMessagesReadSinceLastHeartBeat
+                };
+
+                this.Reset();
+                return telemetryEvent;
+            }
+        }
+
+        private void Reset()
+        {
+            _numberOfMessagesReadSinceLastHeartBeat = 0;
+            _numberOfTimesNoMessagesReadSinceLastHeartBeat = 0;
+        }
+    }
+}

--- a/src/CaptainHook.EventReaderService/HeartBeat/HeartBeatStats.cs
+++ b/src/CaptainHook.EventReaderService/HeartBeat/HeartBeatStats.cs
@@ -19,6 +19,10 @@ namespace CaptainHook.EventReaderService.HeartBeat
 
         private int _numberOfTimesNoMessagesReadSinceLastHeartBeat;
 
+        private int _numberOfDeliveredMessagesSinceLastHeartBeat;
+
+        private int _numberOfUndeliveredMessagesSinceLastHeartBeat;
+
         private readonly bool _enabled;
 
         public HeartBeatStats(bool enabled)
@@ -77,7 +81,9 @@ namespace CaptainHook.EventReaderService.HeartBeat
                     LastTimeMessagesReadUtc = _lastTimeMessagesReadUtc,
                     NumberOfMessagesReadLastTime = _numberOfMessagesReadLastTime,
                     NumberOfTimesNoMessagesReadSinceLastHeartBeat = _numberOfTimesNoMessagesReadSinceLastHeartBeat,
-                    NumberOfMessagesReadSinceLastHeartBeat = _numberOfMessagesReadSinceLastHeartBeat
+                    NumberOfMessagesReadSinceLastHeartBeat = _numberOfMessagesReadSinceLastHeartBeat,
+                    NumberOfMessagesDeliveredSinceLastHeartBeat = _numberOfDeliveredMessagesSinceLastHeartBeat,
+                    NumberOfMessagesUndeliveredSinceLastHeartBeat = _numberOfUndeliveredMessagesSinceLastHeartBeat
                 };
 
                 this.Reset();
@@ -85,10 +91,32 @@ namespace CaptainHook.EventReaderService.HeartBeat
             }
         }
 
+        public void ReportCompleteMessage(bool messageDelivered)
+        {
+            if (!_enabled)
+            {
+                return;
+            }
+
+            lock (_syncObject)
+            {
+                if (messageDelivered)
+                {
+                    _numberOfDeliveredMessagesSinceLastHeartBeat++;
+                }
+                else
+                {
+                    _numberOfUndeliveredMessagesSinceLastHeartBeat++;
+                }
+            }
+        }
+
         private void Reset()
         {
-            _numberOfMessagesReadSinceLastHeartBeat = 0;
-            _numberOfTimesNoMessagesReadSinceLastHeartBeat = 0;
+            _numberOfMessagesReadSinceLastHeartBeat =
+            _numberOfTimesNoMessagesReadSinceLastHeartBeat =
+            _numberOfUndeliveredMessagesSinceLastHeartBeat =
+            _numberOfDeliveredMessagesSinceLastHeartBeat = 0;
         }
     }
 }

--- a/src/CaptainHook.EventReaderService/HeartBeat/ReaderHeartBeatEvent.cs
+++ b/src/CaptainHook.EventReaderService/HeartBeat/ReaderHeartBeatEvent.cs
@@ -21,5 +21,9 @@ namespace CaptainHook.EventReaderService.HeartBeat
         public int NumberOfTimesNoMessagesReadSinceLastHeartBeat { get; set; }
 
         public int NumberOfMessagesReadSinceLastHeartBeat { get; set; }
+
+        public int NumberOfMessagesDeliveredSinceLastHeartBeat { get; set; }
+
+        public int NumberOfMessagesUndeliveredSinceLastHeartBeat { get; set; }
     }
 }

--- a/src/CaptainHook.EventReaderService/HeartBeat/ReaderHeartBeatEvent.cs
+++ b/src/CaptainHook.EventReaderService/HeartBeat/ReaderHeartBeatEvent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Fabric;
+using CaptainHook.Common.Telemetry.Service;
+
+namespace CaptainHook.EventReaderService.HeartBeat
+{
+    public class ReaderHeartBeatEvent: ServiceTelemetryEvent
+    {
+        public ReaderHeartBeatEvent(StatefulServiceContext context): base(context)
+        {
+        }
+
+        public int NumberOfMessagesInFlight { get; set; }
+
+        public int NumberOfAvailableHandlers { get; set; }
+
+        public DateTime? LastTimeMessagesReadUtc { get; set; }
+
+        public int NumberOfMessagesReadLastTime { get; set; }
+
+        public int NumberOfTimesNoMessagesReadSinceLastHeartBeat { get; set; }
+
+        public int NumberOfMessagesReadSinceLastHeartBeat { get; set; }
+    }
+}

--- a/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
@@ -1,4 +1,5 @@
-﻿using CaptainHook.Common.Authentication;
+﻿using System;
+using CaptainHook.Common.Authentication;
 using CaptainHook.Common.Configuration;
 using CaptainHook.Common.ServiceModels;
 using Eshopworld.Tests.Core;
@@ -102,6 +103,51 @@ namespace CaptainHook.Tests.Services.Reliable
             eventReaderInitData.SubscriberName.Should().Be(_subscriberConfiguration.SubscriberName);
             eventReaderInitData.EventType.Should().Be(_subscriberConfiguration.EventType);
             eventReaderInitData.SubscriberConfiguration.Should().BeEquivalentTo(_subscriberConfiguration);
+        }
+
+        [Fact, IsUnit]
+        public void FromSubscriberConfiguration_HeartBeatIntervalInSeconds_MapsToTimeSpan()
+        {
+            // Arrange
+            var heartBeatDisabledSubscriber = new SubscriberConfiguration
+            {
+                HeartBeatInterval = "00:00:05"
+            };
+
+            // Act
+            var initData = EventReaderInitData.FromSubscriberConfiguration(heartBeatDisabledSubscriber, _webhookConfig);
+
+            // Assert
+            initData.HeartBeatInterval.Should().Be(TimeSpan.FromSeconds(5.0));
+        }
+
+        [Fact, IsUnit]
+        public void FromSubscriberConfiguration_HeartBeatIntervalInMinutes_MapsToTimeSpan()
+        {
+            // Arrange
+            var heartBeatDisabledSubscriber = new SubscriberConfiguration
+            {
+                HeartBeatInterval = "00:06:00"
+            };
+
+            // Act
+            var initData = EventReaderInitData.FromSubscriberConfiguration(heartBeatDisabledSubscriber, _webhookConfig);
+
+            // Assert
+            initData.HeartBeatInterval.Should().Be(TimeSpan.FromMinutes(6.0));
+        }
+
+        [Fact, IsUnit]
+        public void FromSubscriberConfiguration_HeartBeatIntervalUnavailable_MapsToNullTimeSpan()
+        {
+            // Arrange
+            var heartBeatDisabledSubscriber = new SubscriberConfiguration();
+
+            // Act
+            var initData = EventReaderInitData.FromSubscriberConfiguration(heartBeatDisabledSubscriber, _webhookConfig);
+
+            // Assert
+            initData.HeartBeatInterval.Should().BeNull();
         }
     }
 }

--- a/src/Tests/CaptainHook.Tests/Services/Reliable/HeartBeat/HeartBeatStatsTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Reliable/HeartBeat/HeartBeatStatsTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Fabric;
+using CaptainHook.Common;
+using CaptainHook.EventReaderService.HeartBeat;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace CaptainHook.Tests.Services.Reliable.HeartBeat
+{
+    public class HeartBeatStatsTests
+    {
+        private readonly HeartBeatStats _heartBeat = new HeartBeatStats(true);
+
+        private readonly StatefulServiceContext _context;
+
+        public HeartBeatStatsTests()
+        {
+            _context = CustomMockStatefulServiceContextFactory.Create(
+                ServiceNaming.EventReaderServiceType,
+                ServiceNaming.EventReaderServiceFullUri("test.type", "subA"),
+                null,
+                replicaId: (new Random(int.MaxValue)).Next());
+        }
+
+        [Fact, IsUnit]
+        public void ReportInFlight_ReflectedInTelemetry()
+        {
+            // Act
+            _heartBeat.ReportInFlight(5, 15);
+            var telemetryEvent = _heartBeat.ToTelemetryEvent(_context);
+
+            // Assert
+            var expected = new ReaderHeartBeatEvent(_context)
+            {
+                NumberOfMessagesInFlight = 5,
+                NumberOfAvailableHandlers = 15
+            };
+            telemetryEvent.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact, IsUnit]
+        public void ReportMessagesRead_Above0_ReflectedInTelemetry()
+        {
+            // Act
+            _heartBeat.ReportMessagesRead(5);
+            var telemetryEvent = _heartBeat.ToTelemetryEvent(_context);
+
+            // Assert
+            var expected = new ReaderHeartBeatEvent(_context)
+            {
+                NumberOfMessagesReadLastTime = 5,
+                NumberOfMessagesReadSinceLastHeartBeat = 5,
+                NumberOfTimesNoMessagesReadSinceLastHeartBeat = 0
+            };
+            telemetryEvent.Should().BeEquivalentTo(expected, config => config
+                .Using<DateTime?>(context => context.Subject.Should().NotBeNull())
+                .WhenTypeIs<DateTime?>());
+        }
+
+        [Fact, IsUnit]
+        public void ReportMessagesRead_Above0_Then_Above0_ReflectedInTelemetry()
+        {
+            // Act
+            _heartBeat.ReportMessagesRead(5);
+            _heartBeat.ReportMessagesRead(6);
+            var telemetryEvent = _heartBeat.ToTelemetryEvent(_context);
+
+            // Assert
+            var expected = new ReaderHeartBeatEvent(_context)
+            {
+                NumberOfMessagesReadLastTime = 6,
+                NumberOfMessagesReadSinceLastHeartBeat = 11,
+                NumberOfTimesNoMessagesReadSinceLastHeartBeat = 0
+            };
+            telemetryEvent.Should().BeEquivalentTo(expected, config => config
+                .Using<DateTime?>(context => context.Subject.Should().NotBeNull())
+                .WhenTypeIs<DateTime?>());
+        }
+
+        [Fact, IsUnit]
+        public void ReportMessagesRead_Above0_Then_0_Then_0_ReflectedInTelemetry()
+        {
+            // Act
+            _heartBeat.ReportMessagesRead(5);
+            _heartBeat.ReportMessagesRead(0);
+            _heartBeat.ReportMessagesRead(0);
+            var telemetryEvent = _heartBeat.ToTelemetryEvent(_context);
+
+            // Assert
+            var expected = new ReaderHeartBeatEvent(_context)
+            {
+                NumberOfMessagesReadLastTime = 0,
+                NumberOfMessagesReadSinceLastHeartBeat = 5,
+                NumberOfTimesNoMessagesReadSinceLastHeartBeat = 2
+            };
+            telemetryEvent.Should().BeEquivalentTo(expected, config => config
+                .Using<DateTime?>(context => context.Subject.Should().NotBeNull())
+                .WhenTypeIs<DateTime?>());
+        }
+
+        [Fact, IsUnit]
+        public void ToTelemetryEvent_CalledMultipleTimes_ResetsAggregatesBetweenCalls()
+        {
+            // Act
+            _heartBeat.ReportInFlight(5, 15);
+            _heartBeat.ReportMessagesRead(5);
+            var _ = _heartBeat.ToTelemetryEvent(_context);
+            var telemetryEvent2 = _heartBeat.ToTelemetryEvent(_context);
+
+            // Assert
+            var expected = new ReaderHeartBeatEvent(_context)
+            {
+                NumberOfMessagesInFlight = 5,
+                NumberOfAvailableHandlers = 15,
+                NumberOfMessagesReadLastTime = 5,
+                NumberOfMessagesReadSinceLastHeartBeat = 0,
+                NumberOfTimesNoMessagesReadSinceLastHeartBeat = 0
+            };
+            telemetryEvent2.Should().BeEquivalentTo(expected, config => config
+                .Using<DateTime?>(context => context.Subject.Should().NotBeNull())
+                .WhenTypeIs<DateTime?>());
+        }
+
+        [Fact, IsUnit]
+        public void HeartBeatDisabled_ToTelemetryEvent_ThrowsException()
+        {
+            // Act
+            var heartBeatDisabled = new HeartBeatStats(false);
+            Func<ReaderHeartBeatEvent> toTelemetryAction = () => heartBeatDisabled.ToTelemetryEvent(_context);
+
+            // Assert
+            toTelemetryAction.Should().Throw<NotSupportedException>().Which.Message
+                .Should().Be("Heart Beat monitoring is disabled for service: fabric:/CaptainHook/EventReader.test.type-subA");
+        }
+    }
+}


### PR DESCRIPTION
### What
Heart Beat telemetry event for Event Reader is sent on a regular interval

### Why
We want to learn certain properties of Event Reader operations which we can then put on a graph to understand the change in behaviour over time. Especially we are going to be able to monitor communication with Service Bus and potential issues there.

### Remarks
Things to be added (separate PR):
- conditional logic to control whether heartbeat is enabled or disabled and control the publish period (will be done on the subscriber level)
- counter for delivered/undelivered messages to be added