### PR TITLE
#72613 - introduce heart beat toggle on the subscriber level

### DIFF
--- a/src/CaptainHook.Cli.Tests/GenerateJson/EventTests.cs
+++ b/src/CaptainHook.Cli.Tests/GenerateJson/EventTests.cs
@@ -48,5 +48,14 @@ namespace CaptainHook.Cli.Tests.GenerateJson
             JsonResult["CallbackConfig"]
                 .Should().BeOfType<JObject>();
         }
+
+        [Fact, IsLayer0]
+        public async Task SupportsHeartBeatConfig()
+        {
+            PrepareCommand();
+            await Command.OnExecuteAsync(Application, Console);
+            JsonResult["HeartBeatInterval"]
+                .Should().BeOfType<JValue>().Which.Value<string>().Should().Be("00:00:05");
+        }
     }
 }

--- a/src/CaptainHook.Cli.Tests/GeneratePowerShell/ConfigDirectoryProcessorTests.cs
+++ b/src/CaptainHook.Cli.Tests/GeneratePowerShell/ConfigDirectoryProcessorTests.cs
@@ -17,7 +17,8 @@ namespace CaptainHook.Cli.Tests.GeneratePowerShell
             fileSystem.AddFile(@"C:\Test\event-10-testevent.json", $"{{\r\n\"Type\": \"type10\" \r\n}}");
             fileSystem.AddFile(@"C:\Test\event-11-testevent.json", $"{{\r\n\"Type\": \"type11\" \r\n}}");
             fileSystem.AddFile(@"C:\Test\event-101-testevent.json", $"{{\r\n\"Type\": \"type101\" \r\n}}");
-            fileSystem.AddFile(@"C:\Test\event-2-testevent.json", $"{{\r\n\"Type\": \"type2\" \r\n}}");
+            fileSystem.AddFile(@"C:\Test\event-2-testevent.json", $"{{\r\n\"Type\": \"type2\",\r\n\"HeartBeatInterval\":\"\" \r\n}}");
+            fileSystem.AddFile(@"C:\Test\event-3-testevent.json", $"{{\r\n\"Type\": \"type3\",\r\n\"HeartBeatInterval\":\"00:00:05\" \r\n}}");
 
         }
 
@@ -28,6 +29,9 @@ namespace CaptainHook.Cli.Tests.GeneratePowerShell
             {
                 "setConfig 'event--1--type' 'type1' $KeyVault",
                 "setConfig 'event--2--type' 'type2' $KeyVault",
+                "setConfig 'event--2--heartbeatinterval' '' $KeyVault",
+                "setConfig 'event--3--type' 'type3' $KeyVault",
+                "setConfig 'event--3--heartbeatinterval' '00:00:05' $KeyVault",
                 "setConfig 'event--10--type' 'type10' $KeyVault",
                 "setConfig 'event--11--type' 'type11' $KeyVault",
                 "setConfig 'event--101--type' 'type101' $KeyVault",
@@ -54,6 +58,9 @@ namespace CaptainHook.Cli.Tests.GeneratePowerShell
                 "def from header",
                 "setConfig 'event--1--type' 'type1' $KeyVault",
                 "setConfig 'event--2--type' 'type2' $KeyVault",
+                "setConfig 'event--2--heartbeatinterval' '' $KeyVault",
+                "setConfig 'event--3--type' 'type3' $KeyVault",
+                "setConfig 'event--3--heartbeatinterval' '00:00:05' $KeyVault",
                 "setConfig 'event--10--type' 'type10' $KeyVault",
                 "setConfig 'event--11--type' 'type11' $KeyVault",
                 "setConfig 'event--101--type' 'type101' $KeyVault",

--- a/src/CaptainHook.Cli.Tests/SampleFile.ps1
+++ b/src/CaptainHook.Cli.Tests/SampleFile.ps1
@@ -46,6 +46,8 @@ setConfig 'CaptainHook--RequiredScopes--1' 'aaa.bbb.ccc' $KeyVault
 #First Domain Event 
 setConfig 'event--1--type' 'activity1.domain.infrastructure.domainevents.activityconfirmationdomainevent' $KeyVault
 setConfig 'event--1--name' 'activity1.domain.infrastructure.domainevents.activityconfirmationdomainevent' $KeyVault
+setConfig 'event--1--heartbeatinterval' '00:00:05' $KeyVault
+
 setConfig 'event--1--webhookconfig--name' 'activity1.domain.infrastructure.domainevents.activityconfirmationdomainevent-webhook' $KeyVault
 setConfig 'event--1--webhookconfig--uri' 'https://ct.site.com/api/v1/WebHook/Update' $KeyVault
 setConfig 'event--1--webhookconfig--authenticationconfig--type' 2 $KeyVault

--- a/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
+++ b/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
@@ -157,12 +157,18 @@ namespace CaptainHook.Common.Configuration
         public bool IsMainConfiguration { get; private set; }
 
         /// <summary>
+        /// Provide this value as TimeSpan format to send HeartBeat telemetry event from Event Reader
+        /// </summary>
+        public string HeartBeatInterval { get; set; }
+
+        /// <summary>
         /// Tranforms the old structure of configuration into the new one.
         /// </summary>
         /// <param name="webhookConfig">The webhook configuration.</param>
         /// <param name="callback">The callback associated with <paramref name="webhookConfig"/>.</param>
+        /// <param name="heartBeatInterval">Heart Beat Interval value if applicable.</param>
         /// <returns>The subscriber configuration consisting of the webhook configuration and its callback.</returns>
-        public static SubscriberConfiguration FromWebhookConfig(WebhookConfig webhookConfig, WebhookConfig callback)
+        public static SubscriberConfiguration FromWebhookConfig(WebhookConfig webhookConfig, WebhookConfig callback, string heartBeatInterval)
         {
             return new SubscriberConfiguration
             {
@@ -177,6 +183,7 @@ namespace CaptainHook.Common.Configuration
                 WebhookRequestRules = webhookConfig.WebhookRequestRules,
                 Callback = callback,
                 IsMainConfiguration = true,
+                HeartBeatInterval = heartBeatInterval
             };
         }
 
@@ -209,7 +216,7 @@ namespace CaptainHook.Common.Configuration
         /// <summary>
         /// The list of all subscibers of the topic handling the event type.
         /// </summary>
-        [JsonProperty(Order = 5)]
+        [JsonProperty(Order = 6)]
         public List<SubscriberConfiguration> Subscribers { get; } = new List<SubscriberConfiguration>();
 
         /// <summary>
@@ -221,7 +228,7 @@ namespace CaptainHook.Common.Configuration
             get
             {
                 if (WebhookConfig != null)
-                    yield return SubscriberConfiguration.FromWebhookConfig(WebhookConfig, CallbackConfig);
+                    yield return SubscriberConfiguration.FromWebhookConfig(WebhookConfig, CallbackConfig, HeartBeatInterval);
                 foreach (var conf in Subscribers)
                 {
                     conf.CollectionIndex = Subscribers.IndexOf(conf);
@@ -247,6 +254,9 @@ namespace CaptainHook.Common.Configuration
 
         [JsonProperty(Order = 1)]
         public string Type { get; set; }
+
+        [JsonProperty(Order = 5)]
+        public string HeartBeatInterval { get; set; }
     }
 
     public class WebhookRequestRule

--- a/src/CaptainHook.Common/ServiceModels/EventReaderInitData.cs
+++ b/src/CaptainHook.Common/ServiceModels/EventReaderInitData.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Text;
 using CaptainHook.Common.Configuration;
 using CaptainHook.Common.Json;
@@ -24,6 +25,8 @@ namespace CaptainHook.Common.ServiceModels
 
         public string SubscriptionName => DlqMode != null ? SourceSubscription : SubscriberName;
 
+        public TimeSpan? HeartBeatInterval { get; set; }
+
         private static JsonIgnoreAttributeIgnorerContractResolver jsonIgnoreAttributeIgnorerContractResolver = new JsonIgnoreAttributeIgnorerContractResolver();
 
         private static AuthenticationConfigConverter authenticationConfigConverter = new AuthenticationConfigConverter();
@@ -37,7 +40,8 @@ namespace CaptainHook.Common.ServiceModels
                 EventType = subscriberConfiguration.EventType,
                 DlqMode = subscriberConfiguration.DLQMode,
                 SourceSubscription = subscriberConfiguration.DLQMode != null ? subscriberConfiguration.SourceSubscriptionName : null,
-                WebhookConfig = webhookConfig
+                WebhookConfig = webhookConfig,
+                HeartBeatInterval = TimeSpan.TryParse(subscriberConfiguration.HeartBeatInterval, out var heartBeatInterval) ? heartBeatInterval : (TimeSpan?)null
             };
         }
 

--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -151,8 +151,14 @@ namespace CaptainHook.EventReaderService
         protected override async Task OnOpenAsync(ReplicaOpenMode openMode, CancellationToken cancellationToken)
         {
             _bigBrother.Publish(new ServiceActivatedEvent(Context, InFlightMessageCount));
-            _heartBeatTimer = new Timer(HeartBeatTimerCallback, null, TimeSpan.FromSeconds(1.0), TimeSpan.FromSeconds(10.0));
-            _heartBeatStats = new HeartBeatStats(true);
+
+            var heartBeatEnabled = _initData.HeartBeatInterval != null;
+            _heartBeatStats = new HeartBeatStats(heartBeatEnabled);
+            if (heartBeatEnabled)
+            {
+                _heartBeatTimer = new Timer(HeartBeatTimerCallback, null, TimeSpan.FromSeconds(1.0), _initData.HeartBeatInterval.Value);
+            }
+
             await base.OnOpenAsync(openMode, cancellationToken);
         }
 

--- a/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
@@ -1,4 +1,5 @@
-﻿using CaptainHook.Common.Authentication;
+﻿using System;
+using CaptainHook.Common.Authentication;
 using CaptainHook.Common.Configuration;
 using CaptainHook.Common.ServiceModels;
 using Eshopworld.Tests.Core;
@@ -102,6 +103,51 @@ namespace CaptainHook.Tests.Services.Reliable
             eventReaderInitData.SubscriberName.Should().Be(_subscriberConfiguration.SubscriberName);
             eventReaderInitData.EventType.Should().Be(_subscriberConfiguration.EventType);
             eventReaderInitData.SubscriberConfiguration.Should().BeEquivalentTo(_subscriberConfiguration);
+        }
+
+        [Fact, IsUnit]
+        public void FromSubscriberConfiguration_HeartBeatIntervalInSeconds_MapsToTimeSpan()
+        {
+            // Arrange
+            var heartBeatDisabledSubscriber = new SubscriberConfiguration
+            {
+                HeartBeatInterval = "00:00:05"
+            };
+
+            // Act
+            var initData = EventReaderInitData.FromSubscriberConfiguration(heartBeatDisabledSubscriber, _webhookConfig);
+
+            // Assert
+            initData.HeartBeatInterval.Should().Be(TimeSpan.FromSeconds(5.0));
+        }
+
+        [Fact, IsUnit]
+        public void FromSubscriberConfiguration_HeartBeatIntervalInMinutes_MapsToTimeSpan()
+        {
+            // Arrange
+            var heartBeatDisabledSubscriber = new SubscriberConfiguration
+            {
+                HeartBeatInterval = "00:06:00"
+            };
+
+            // Act
+            var initData = EventReaderInitData.FromSubscriberConfiguration(heartBeatDisabledSubscriber, _webhookConfig);
+
+            // Assert
+            initData.HeartBeatInterval.Should().Be(TimeSpan.FromMinutes(6.0));
+        }
+
+        [Fact, IsUnit]
+        public void FromSubscriberConfiguration_HeartBeatIntervalUnavailable_MapsToNullTimeSpan()
+        {
+            // Arrange
+            var heartBeatDisabledSubscriber = new SubscriberConfiguration();
+
+            // Act
+            var initData = EventReaderInitData.FromSubscriberConfiguration(heartBeatDisabledSubscriber, _webhookConfig);
+
+            // Assert
+            initData.HeartBeatInterval.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
### What
Introduce a toggle which allows us to enable/disable the heart beat per subscriber. By default it is going to be disabled.

### Example
`setConfig 'event--1--heartbeatinterval' '00:00:05' $KeyVault`
Use TimeSpan values to provide the wait interval. Remove the entry to disable heart beat.
Reload fully supported.