### PR TITLE
#73562 - ensure Merge uses EventType and SubscriberName for matching

### DIFF
--- a/src/CaptainHook.DirectorService/Infrastructure/ConfigurationMerger.cs
+++ b/src/CaptainHook.DirectorService/Infrastructure/ConfigurationMerger.cs
@@ -67,7 +67,7 @@ namespace CaptainHook.DirectorService.Infrastructure
         {
             var config = new SubscriberConfiguration
             {
-                Name = cosmosModel.SubscriberId,
+                Name = $"{cosmosModel.ParentEvent.Name}-{cosmosModel.Name}",
                 SubscriberName = cosmosModel.Name,
                 EventType = cosmosModel.ParentEvent.Name,
                 Uri = cosmosModel.Webhooks.Endpoints.First().Uri,

--- a/src/CaptainHook.DirectorService/Infrastructure/ConfigurationMerger.cs
+++ b/src/CaptainHook.DirectorService/Infrastructure/ConfigurationMerger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -32,7 +32,7 @@ namespace CaptainHook.DirectorService.Infrastructure
         {
             var onlyInKv = subscribersFromKeyVault
                 .Where(kvSubscriber => !subscribersFromCosmos.Any(cosmosSubscriber =>
-                    kvSubscriber.Name.Equals(cosmosSubscriber.ParentEvent.Name, StringComparison.InvariantCultureIgnoreCase)
+                    kvSubscriber.EventType.Equals(cosmosSubscriber.ParentEvent.Name, StringComparison.InvariantCultureIgnoreCase)
                     && kvSubscriber.SubscriberName.Equals(cosmosSubscriber.Name, StringComparison.InvariantCultureIgnoreCase)));
 
             async Task<IEnumerable<SubscriberConfiguration>> MapCosmosEntries()
@@ -67,13 +67,15 @@ namespace CaptainHook.DirectorService.Infrastructure
         {
             var config = new SubscriberConfiguration
             {
-                Name = cosmosModel.ParentEvent.Name,
+                Name = cosmosModel.SubscriberId,
                 SubscriberName = cosmosModel.Name,
+                EventType = cosmosModel.ParentEvent.Name,
                 Uri = cosmosModel.Webhooks.Endpoints.First().Uri,
                 AuthenticationConfig = await MapAuthentication(cosmosModel.Webhooks.Endpoints.FirstOrDefault()?.Authentication),
                 // Callback handling not needed now
                 //Callback = MapCallback(cosmosModel),
             };
+
             return config;
         }
 

--- a/src/CaptainHook.DirectorService/Infrastructure/ReaderServicesManager.cs
+++ b/src/CaptainHook.DirectorService/Infrastructure/ReaderServicesManager.cs
@@ -108,11 +108,10 @@ namespace CaptainHook.DirectorService.Infrastructure
             }
         }
 
-        private static byte[] BuildInitializationData(SubscriberConfiguration subscriber, IEnumerable<WebhookConfig> webhooks)
+        private static byte[] BuildInitializationData(SubscriberConfiguration subscriber, IEnumerable<WebhookConfig> _)
         {
-            var webhookConfig = webhooks.SingleOrDefault(x => x.Name == subscriber.Name);
             return EventReaderInitData
-                .FromSubscriberConfiguration(subscriber, webhookConfig)
+                .FromSubscriberConfiguration(subscriber, subscriber)
                 .ToByteArray();
         }
     }

--- a/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
+++ b/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
@@ -6,11 +6,6 @@
     public class SubscriberEntity
     {
         /// <summary>
-        /// Unique identifier of the subscriber.
-        /// </summary>
-        public string SubscriberId { get; }
-
-        /// <summary>
         /// Subscriber name.
         /// </summary>
         public string Name { get; }
@@ -25,11 +20,10 @@
         /// </summary>
         public WebhooksEntity Webhooks { get; }
 
-        public SubscriberEntity(string subscriberId, string name) : this(subscriberId, name, null, null) { }
-        public SubscriberEntity(string subscriberId, string name, string webhookSelectionRule) : this(subscriberId, name, webhookSelectionRule, null) { }
-        public SubscriberEntity(string subscriberId, string name, string webhookSelectionRule, EventEntity parentEvent)
+        public SubscriberEntity(string name) : this(name, null, null) { }
+        public SubscriberEntity(string name, string webhookSelectionRule) : this(name, webhookSelectionRule, null) { }
+        public SubscriberEntity(string name, string webhookSelectionRule, EventEntity parentEvent)
         {
-            SubscriberId = subscriberId;
             Name = name;
             Webhooks = new WebhooksEntity(webhookSelectionRule);
 
@@ -45,10 +39,12 @@
         /// Adds an enpoint to the list of webhook endpoints
         /// </summary>
         /// <param name="endpointModel"></param>
-        public void AddWebhookEndpoint(EndpointEntity endpointModel)
+        public SubscriberEntity AddWebhookEndpoint(EndpointEntity endpointModel)
         {
             endpointModel.SetParentSubscriber(this);
             Webhooks.AddEndpoint(endpointModel);
+
+            return this;
         }
     }
 }

--- a/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
+++ b/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
@@ -6,7 +6,12 @@
     public class SubscriberEntity
     {
         /// <summary>
-        /// Subscriber name
+        /// Unique identifier of the subscriber.
+        /// </summary>
+        public string SubscriberId { get; }
+
+        /// <summary>
+        /// Subscriber name.
         /// </summary>
         public string Name { get; }
 
@@ -20,10 +25,11 @@
         /// </summary>
         public WebhooksEntity Webhooks { get; }
 
-        public SubscriberEntity(string name) : this(name, null, null) { }
-        public SubscriberEntity(string name, string webhookSelectionRule) : this(name, webhookSelectionRule, null) { }
-        public SubscriberEntity(string name, string webhookSelectionRule, EventEntity parentEvent)
+        public SubscriberEntity(string subscriberId, string name) : this(subscriberId, name, null, null) { }
+        public SubscriberEntity(string subscriberId, string name, string webhookSelectionRule) : this(subscriberId, name, webhookSelectionRule, null) { }
+        public SubscriberEntity(string subscriberId, string name, string webhookSelectionRule, EventEntity parentEvent)
         {
+            SubscriberId = subscriberId;
             Name = name;
             Webhooks = new WebhooksEntity(webhookSelectionRule);
 

--- a/src/CaptainHook.Storage.Cosmos/Models/EndpointDocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/EndpointDocument.cs
@@ -77,11 +77,5 @@ namespace CaptainHook.Storage.Cosmos.Models
         /// </summary>
         [JsonProperty("eventName")]
         public string EventName { get; set; }
-
-        /// <summary>
-        /// Identifies the subscriber by event and name.
-        /// </summary>
-        [JsonIgnore]
-        public string SubscriberId => $"{EventName}-{SubscriberName}";
     }
 }

--- a/src/CaptainHook.Storage.Cosmos/Models/EndpointDocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/EndpointDocument.cs
@@ -81,7 +81,7 @@ namespace CaptainHook.Storage.Cosmos.Models
         /// <summary>
         /// Identifies the subscriber by event and name.
         /// </summary>
-        [JsonProperty("subscriberId")]
-        public string SubscriberId => $"{EventName}_{SubscriberName}";
+        [JsonIgnore]
+        public string SubscriberId => $"{EventName}-{SubscriberName}";
     }
 }

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -43,7 +43,7 @@ namespace CaptainHook.Storage.Cosmos
             var endpoints = await _cosmosDbRepository.QueryAsync<EndpointDocument>(query);
 
             return endpoints
-                .GroupBy(x => x.SubscriberId)
+                .GroupBy(x => new { x.EventName, x.SubscriberName })
                 .Select(x => Map(x));
         }
 
@@ -65,7 +65,7 @@ namespace CaptainHook.Storage.Cosmos
             var endpoints = await _cosmosDbRepository.QueryAsync<EndpointDocument>(query);
 
             return endpoints
-                .GroupBy(x => x.SubscriberId)
+                .GroupBy(x => new { x.EventName, x.SubscriberName })
                 .Select(x => Map(x));
         }
 
@@ -93,7 +93,6 @@ namespace CaptainHook.Storage.Cosmos
             var eventEntity = new EventEntity(endpointDocument.EventName);
 
             var subscriber = new SubscriberEntity(
-                endpointDocument.SubscriberId,
                 endpointDocument.SubscriberName,
                 webhookSelectionRule,
                 eventEntity);

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -93,6 +93,7 @@ namespace CaptainHook.Storage.Cosmos
             var eventEntity = new EventEntity(endpointDocument.EventName);
 
             var subscriber = new SubscriberEntity(
+                endpointDocument.SubscriberId,
                 endpointDocument.SubscriberName,
                 webhookSelectionRule,
                 eventEntity);

--- a/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
+++ b/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
@@ -97,7 +97,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 .Setup(x => x.QueryAsync<EndpointDocument>(It.IsAny<CosmosQuery>()))
                 .ReturnsAsync(new List<EndpointDocument> { sampleDocument });
 
-            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
+            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberId, sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
             var sampleAuthStoreEntity = new SecretStoreEntity(sampleDocument.Authentication.KeyVaultName, sampleDocument.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(sampleDocument.Authentication.ClientId, sampleAuthStoreEntity, sampleDocument.Authentication.Uri, sampleDocument.Authentication.Type, sampleDocument.Authentication.Scopes);
             var expectedEndpointEntity = new EndpointEntity(sampleDocument.Uri, expectedAuthenticationEntity, sampleDocument.HttpVerb, sampleDocument.EndpointSelector);

--- a/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
+++ b/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
@@ -1,15 +1,12 @@
 using CaptainHook.Domain.Entities;
-using CaptainHook.Storage.Cosmos;
 using CaptainHook.Storage.Cosmos.Models;
 using CaptainHook.Storage.Cosmos.QueryBuilders;
 using Eshopworld.Data.CosmosDb;
 using Eshopworld.Tests.Core;
 using FluentAssertions;
-using FluentAssertions.Execution;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -97,7 +94,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 .Setup(x => x.QueryAsync<EndpointDocument>(It.IsAny<CosmosQuery>()))
                 .ReturnsAsync(new List<EndpointDocument> { sampleDocument });
 
-            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberId, sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
+            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
             var sampleAuthStoreEntity = new SecretStoreEntity(sampleDocument.Authentication.KeyVaultName, sampleDocument.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(sampleDocument.Authentication.ClientId, sampleAuthStoreEntity, sampleDocument.Authentication.Uri, sampleDocument.Authentication.Type, sampleDocument.Authentication.Scopes);
             var expectedEndpointEntity = new EndpointEntity(sampleDocument.Uri, expectedAuthenticationEntity, sampleDocument.HttpVerb, sampleDocument.EndpointSelector);
@@ -107,12 +104,89 @@ namespace CaptainHook.Storage.Cosmos.Tests
             var result = await repository.GetSubscribersListAsync(eventName);
 
             // Assert
-            result.Should()
-                .HaveCount(1)
-                .And
-                .BeEquivalentTo(new [] { expectedSubscriberEntity }, 
-                    options => options
-                        .Excluding(x => x.SelectedMemberPath == "Webhooks.Endpoints[0].ParentSubscriber"));
+            result.Should().BeEquivalentTo(new [] { expectedSubscriberEntity }, options => options.IgnoringCyclicReferences());
+        }
+
+        [Fact, IsUnit]
+        public async Task TestMethodName()
+        {
+            // Arrange
+            const string eventName = "eventName";
+            var response = new[]
+            {
+                new EndpointDocument
+                {
+                    SubscriberName = "subscriberName",
+                    EventName = eventName,
+                    HttpVerb = "POST",
+                    Uri = "http://test",
+                    EndpointSelector = "selector",
+                    WebhookType = WebhookType.Webhook,
+                    WebhookSelectionRule = "rule",
+                    Authentication = new AuthenticationData
+                    {
+                        ClientId = "clientid",
+                        KeyVaultName = "keyvaultname",
+                        Scopes = new[] { "scope" },
+                        SecretName = "secret",
+                        Type = "type",
+                        Uri = "uri"
+                    }
+                },
+                new EndpointDocument
+                {
+                    SubscriberName = "subscriberName",
+                    EventName = eventName,
+                    HttpVerb = "GET",
+                    Uri = "http://test2",
+                    EndpointSelector = "selector2",
+                    WebhookType = WebhookType.Webhook,
+                    WebhookSelectionRule = "rule",
+                    Authentication = new AuthenticationData
+                    {
+                        ClientId = "clientid",
+                        KeyVaultName = "keyvaultname",
+                        Scopes = new[] { "scope" },
+                        SecretName = "secret",
+                        Type = "type",
+                        Uri = "uri"
+                    }
+                },
+            };
+
+            _cosmosDbRepositoryMock
+                .Setup(x => x.QueryAsync<EndpointDocument>(It.IsAny<CosmosQuery>()))
+                .ReturnsAsync(response);
+
+            // Act
+            var result = await repository.GetSubscribersListAsync(eventName);
+
+            // Assert
+            var expected = new[]
+            {
+                new SubscriberEntity("subscriberName", "rule", new EventEntity(eventName))
+                    .AddWebhookEndpoint(new EndpointEntity(
+                        "http://test",
+                        new AuthenticationEntity(
+                            "clientid",
+                            new SecretStoreEntity("keyvaultname", "secret"),
+                            "uri",
+                            "type",
+                            new[] { "scope" }),
+                        "POST",
+                        "selector"))
+                    .AddWebhookEndpoint(
+                        new EndpointEntity("http://test2",
+                        new AuthenticationEntity(
+                            "clientid",
+                            new SecretStoreEntity("keyvaultname", "secret"),
+                            "uri",
+                            "type",
+                            new[] { "scope" }),
+                        "GET",
+                        "selector2"))
+            };
+            result.Should().BeEquivalentTo(expected, options => options.IgnoringCyclicReferences());
         }
     }
 }

--- a/src/Tests/CaptainHook.Tests/Builders/SubscriberBuilder.cs
+++ b/src/Tests/CaptainHook.Tests/Builders/SubscriberBuilder.cs
@@ -5,6 +5,7 @@ namespace CaptainHook.Tests.Builders
 {
     internal class SubscriberBuilder
     {
+        private string _subscriberId;
         private string _name = "captain-hook";
         private EventEntity _event;
         private readonly List<EndpointEntity> _webhooks = new List<EndpointEntity>();
@@ -14,6 +15,12 @@ namespace CaptainHook.Tests.Builders
         public SubscriberBuilder WithName(string name)
         {
             _name = name;
+            return this;
+        }
+
+        public SubscriberBuilder WithSubscriberId(string subscriberId)
+        {
+            _subscriberId = subscriberId;
             return this;
         }
 
@@ -46,7 +53,7 @@ namespace CaptainHook.Tests.Builders
 
         public SubscriberEntity Create()
         {
-            var subscriber = new SubscriberEntity(_name);
+            var subscriber = new SubscriberEntity(_subscriberId, _name);
             subscriber.SetParentEvent(_event);
 
             _webhooks.ForEach(x => subscriber.AddWebhookEndpoint(x));

--- a/src/Tests/CaptainHook.Tests/Builders/SubscriberBuilder.cs
+++ b/src/Tests/CaptainHook.Tests/Builders/SubscriberBuilder.cs
@@ -5,7 +5,6 @@ namespace CaptainHook.Tests.Builders
 {
     internal class SubscriberBuilder
     {
-        private string _subscriberId;
         private string _name = "captain-hook";
         private EventEntity _event;
         private readonly List<EndpointEntity> _webhooks = new List<EndpointEntity>();
@@ -15,12 +14,6 @@ namespace CaptainHook.Tests.Builders
         public SubscriberBuilder WithName(string name)
         {
             _name = name;
-            return this;
-        }
-
-        public SubscriberBuilder WithSubscriberId(string subscriberId)
-        {
-            _subscriberId = subscriberId;
             return this;
         }
 
@@ -53,7 +46,7 @@ namespace CaptainHook.Tests.Builders
 
         public SubscriberEntity Create()
         {
-            var subscriber = new SubscriberEntity(_subscriberId, _name);
+            var subscriber = new SubscriberEntity(_name);
             subscriber.SetParentEvent(_event);
 
             _webhooks.ForEach(x => subscriber.AddWebhookEndpoint(x));

--- a/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
@@ -99,7 +99,6 @@ namespace CaptainHook.Tests.Director
             {
                 new SubscriberBuilder()
                     .WithEvent("testevent")
-                    .WithSubscriberId("testevent-captain-hook")
                     .WithWebhook(
                         "https://cosmos.eshopworld.com/testevent/",
                         "POST",

--- a/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
@@ -53,9 +53,9 @@ namespace CaptainHook.Tests.Director
             using (new AssertionScope())
             {
                 result.Should().HaveCount(3);
-                result.Should().Contain(x => x.Name == "testevent" && x.SubscriberName == "captain-hook");
-                result.Should().Contain(x => x.Name == "testevent" && x.SubscriberName == "subscriber1");
-                result.Should().Contain(x => x.Name == "testevent.completed" && x.SubscriberName == "captain-hook");
+                result.Should().Contain(x => x.EventType == "testevent" && x.SubscriberName == "captain-hook");
+                result.Should().Contain(x => x.EventType == "testevent" && x.SubscriberName == "subscriber1");
+                result.Should().Contain(x => x.EventType == "testevent.completed" && x.SubscriberName == "captain-hook");
             }
         }
 
@@ -82,13 +82,13 @@ namespace CaptainHook.Tests.Director
             {
                 result.Should().HaveCount(5);
 
-                result.Should().Contain(x => x.Name == "TESTevent" && x.SubscriberName == "captain-hook" && x.Uri == "https://cosmos.eshopworld.com/testevent/");
+                result.Should().Contain(x => x.EventType == "TESTevent" && x.SubscriberName == "captain-hook" && x.Uri == "https://cosmos.eshopworld.com/testevent/");
 
-                result.Should().Contain(x => x.Name == "testevent" && x.SubscriberName == "subscriber1" && x.Uri == "https://blah.blah.eshopworld.com");
-                result.Should().Contain(x => x.Name == "testevent.completed" && x.SubscriberName == "captain-hook" && x.Uri == "https://blah.blah.eshopworld.com");
+                result.Should().Contain(x => x.EventType == "testevent" && x.SubscriberName == "subscriber1" && x.Uri == "https://blah.blah.eshopworld.com");
+                result.Should().Contain(x => x.EventType == "testevent.completed" && x.SubscriberName == "captain-hook" && x.Uri == "https://blah.blah.eshopworld.com");
 
-                result.Should().Contain(x => x.Name == "newtestevent" && x.SubscriberName == "subscriber1" && x.Uri == "https://cosmos.eshopworld.com/newtestevent2/");
-                result.Should().Contain(x => x.Name == "newtestevent.completed" && x.SubscriberName == "captain-hook" && x.Uri == "https://cosmos.eshopworld.com/newtestevent-completed/");
+                result.Should().Contain(x => x.EventType == "newtestevent" && x.SubscriberName == "subscriber1" && x.Uri == "https://cosmos.eshopworld.com/newtestevent2/");
+                result.Should().Contain(x => x.EventType == "newtestevent.completed" && x.SubscriberName == "captain-hook" && x.Uri == "https://cosmos.eshopworld.com/newtestevent-completed/");
             }
         }
 
@@ -99,6 +99,7 @@ namespace CaptainHook.Tests.Director
             {
                 new SubscriberBuilder()
                     .WithEvent("testevent")
+                    .WithSubscriberId("testevent-captain-hook")
                     .WithWebhook(
                         "https://cosmos.eshopworld.com/testevent/",
                         "POST",
@@ -120,7 +121,8 @@ namespace CaptainHook.Tests.Director
 
             var expectedConfiguration = new SubscriberConfiguration
             {
-                Name = "testevent",
+                Name = "testevent-captain-hook",
+                EventType = "testevent",
                 SubscriberName = "captain-hook",
                 Uri = "https://cosmos.eshopworld.com/testevent/",
                 HttpVerb = "POST",


### PR DESCRIPTION
### What
This PR enables MERGE and RELOAD which were both broken for config changes. *Please ensure to question every line, this PR is ⚠️ crucial*

### Testing
Locally, the following has been tested:
- config in KV
- config in KV and Cosmos independent
- config in KV and Cosmos and KV changed and reloaded
- config in KV and Cosmos and Cosmos changed and reloaded
- config in KV and Cosmos override
- config in KV and Cosmos override changed and reloaded

I am going to perform more tests while this PR is being reviewed.