### PR TITLE
#72765 Upgrade all packages to the latest stable version

### DIFF
--- a/src/CaptainHook.Api/CaptainHook.Api.csproj
+++ b/src/CaptainHook.Api/CaptainHook.Api.csproj
@@ -15,23 +15,23 @@
 
   <ItemGroup>
     <!-- Adding in update for a sub dep until Ms fix the dep tree-->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
-    <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="4.0.470" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="4.0.470" />
-    <PackageReference Include="Autofac" Version="5.1.4" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="4.1.417" />
+    <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Eshopworld.DevOps" Version="5.0.1" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
     <PackageReference Include="Eshopworld.Web" Version="4.0.1" />
-    <PackageReference Include="IdentityServer4" Version="3.1.2" />
+    <PackageReference Include="IdentityServer4" Version="4.0.1" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.0.470" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.417" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Cli/CaptainHook.Cli.csproj
+++ b/src/CaptainHook.Cli/CaptainHook.Cli.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
-    <PackageReference Include="System.IO.Abstractions" Version="11.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
+    <PackageReference Include="System.IO.Abstractions" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Common/CaptainHook.Common.csproj
+++ b/src/CaptainHook.Common/CaptainHook.Common.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
-    <PackageReference Include="IdentityModel" Version="4.2.0" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
+    <PackageReference Include="IdentityModel" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
+++ b/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
@@ -19,11 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="5.1.4" />
+    <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.417" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.EventHandlerActor/CaptainHook.EventHandlerActor.csproj
+++ b/src/CaptainHook.EventHandlerActor/CaptainHook.EventHandlerActor.csproj
@@ -21,14 +21,14 @@
   <ItemGroup>
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
     <PackageReference Include="Eshopworld.DevOps" Version="5.0.1" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
-    <PackageReference Include="IdentityModel" Version="4.2.0" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
+    <PackageReference Include="IdentityModel" Version="4.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
-    <PackageReference Include="Platform.Events" Version="1.3.0" />
-    <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
+    <PackageReference Include="Platform.Events" Version="2.18.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.EventReaderService/CaptainHook.EventReaderService.csproj
+++ b/src/CaptainHook.EventReaderService/CaptainHook.EventReaderService.csproj
@@ -19,13 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="5.1.4" />
+    <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.33.0" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.34.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
-    <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.417" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Fabric/CaptainHook.Fabric.sfproj
+++ b/src/CaptainHook.Fabric/CaptainHook.Fabric.sfproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets=";ValidateMSBuildFiles">
-  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>d44fa61e-30bd-487c-97cb-877e596872a8</ProjectGuid>
     <ProjectVersion>2.3</ProjectVersion>
@@ -51,9 +51,9 @@
     <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
   </PropertyGroup>
   <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
-  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
   <Target Name="ValidateMSBuildFiles" BeforeTargets="PrepareForBuild">
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
-    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.6.10\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
   </Target>
 </Project>

--- a/src/CaptainHook.Fabric/packages.config
+++ b/src/CaptainHook.Fabric/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.9" targetFramework="net47" />
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.6.10" targetFramework="net47" />
 </packages>

--- a/src/CaptainHook.Interfaces/CaptainHook.Interfaces.csproj
+++ b/src/CaptainHook.Interfaces/CaptainHook.Interfaces.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Telemetry/CaptainHook.Telemetry.csproj
+++ b/src/CaptainHook.Telemetry/CaptainHook.Telemetry.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="5.1.4" />
+    <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/CaptainHook.Api.Tests/CaptainHook.Api.Tests.csproj
+++ b/src/Tests/CaptainHook.Api.Tests/CaptainHook.Api.Tests.csproj
@@ -27,16 +27,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EShopworld.Security.Services.Rest" Version="4.0.3" />
-    <PackageReference Include="EShopworld.Security.Services.Testing" Version="2.4.1" />
+    <PackageReference Include="EShopworld.Security.Services.Rest" Version="4.0.4" />
+    <PackageReference Include="EShopworld.Security.Services.Testing" Version="2.6.1" />
     <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tests/CaptainHook.Api.Tests/config/ApiClientFixture.cs
+++ b/src/Tests/CaptainHook.Api.Tests/config/ApiClientFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CaptainHook.Api.Client;
+using EShopworld.Security.Services.Testing.Settings;
 using EShopworld.Security.Services.Testing.Token;
 using Microsoft.Rest;
 
@@ -16,7 +17,13 @@ namespace CaptainHook.Api.Tests.Config
 
         public ICaptainHookClient GetApiClient()
         {
-            var token = new TokenCredentialsBuilder().Build();
+            var tb = new RefreshingTokenProviderOptions(
+                EnvironmentSettings.StsSettings.Issuer, 
+                EnvironmentSettings.StsSettings.Subject, 
+                EnvironmentSettings.StsSettings.ClientId, 
+                EnvironmentSettings.StsSettings.Scopes, 
+                EnvironmentSettings.StsSettings.Audience);
+            var token = new TokenCredentialsBuilder(tb).Build();
             return new CaptainHookClient(CaptainHookTestUri, token);
         }
 

--- a/src/Tests/CaptainHook.Cli.Tests/CaptainHook.Cli.Tests.csproj
+++ b/src/Tests/CaptainHook.Cli.Tests/CaptainHook.Cli.Tests.csproj
@@ -31,13 +31,13 @@
   <ItemGroup>
     <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="11.0.2" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tests/CaptainHook.Telemetry.Tests/CaptainHook.Telemetry.Tests.csproj
+++ b/src/Tests/CaptainHook.Telemetry.Tests/CaptainHook.Telemetry.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tests/CaptainHook.Tests/CaptainHook.Tests.csproj
+++ b/src/Tests/CaptainHook.Tests/CaptainHook.Tests.csproj
@@ -17,21 +17,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eshopworld.Messaging" Version="2.1.2" />
-    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.2" />
+    <PackageReference Include="Eshopworld.Messaging" Version="2.1.3" />
+    <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
     <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.3" />
-    <PackageReference Include="IdentityModel" Version="4.2.0" />
+    <PackageReference Include="IdentityModel" Version="4.3.0" />
     <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.33.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.7" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.34.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.0" />
-    <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="Platform.Events" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
+    <PackageReference Include="Moq" Version="4.14.4" />
+    <PackageReference Include="Platform.Events" Version="2.18.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="ServiceFabric.Mocks" Version="4.1.3" />
+    <PackageReference Include="ServiceFabric.Mocks" Version="4.1.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
All packages have been upgraded to the latest stable version except for Microsoft.Extensions.Configuration.AzureKeyVault which is known in ESW to cause a timeout on any version higher than v. 2.2.0 when concurrently loading a large amount of secrets from a single keyvault.