### PR TITLE
Downgrade of SF libraries to v. 4.0.470

### DIFF
--- a/src/CaptainHook.Api/CaptainHook.Api.csproj
+++ b/src/CaptainHook.Api/CaptainHook.Api.csproj
@@ -17,9 +17,9 @@
     <!-- Adding in update for a sub dep until Ms fix the dep tree-->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
-    <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="4.1.417" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="4.0.470" />
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Eshopworld.DevOps" Version="5.0.1" />
@@ -29,8 +29,8 @@
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.1.417" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.0.470" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
   </ItemGroup>
 

--- a/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
+++ b/src/CaptainHook.DirectorService/CaptainHook.DirectorService.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
     <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.EventHandlerActor/CaptainHook.EventHandlerActor.csproj
+++ b/src/CaptainHook.EventHandlerActor/CaptainHook.EventHandlerActor.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
     <PackageReference Include="Platform.Events" Version="2.18.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>

--- a/src/CaptainHook.EventReaderService/CaptainHook.EventReaderService.csproj
+++ b/src/CaptainHook.EventReaderService/CaptainHook.EventReaderService.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.34.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
     <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 

--- a/src/CaptainHook.Interfaces/CaptainHook.Interfaces.csproj
+++ b/src/CaptainHook.Interfaces/CaptainHook.Interfaces.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Telemetry/CaptainHook.Telemetry.csproj
+++ b/src/CaptainHook.Telemetry/CaptainHook.Telemetry.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
     <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.1.417" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="4.0.470" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/CaptainHook.Tests/CaptainHook.Tests.csproj
+++ b/src/Tests/CaptainHook.Tests/CaptainHook.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Moq" Version="4.14.4" />
     <PackageReference Include="Platform.Events" Version="2.18.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="ServiceFabric.Mocks" Version="4.1.5" />
+    <PackageReference Include="ServiceFabric.Mocks" Version="4.1.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
We are downgrading SF libraries to v. 4.0.470 until the cluster are upgraded to v.7.1.x due to incompatibility.