### PR TITLE
Temporarily move KV test out of unit testing

### DIFF
--- a/src/Tests/CaptainHook.Tests/Director/SubscriberConfigurationLoaderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Director/SubscriberConfigurationLoaderTests.cs
@@ -26,7 +26,7 @@ namespace CaptainHook.Tests.Director
             _subscriberConfigurationLoader = new SubscriberConfigurationLoader(_subscriberRepositoryMock.Object, _configurationMergerMock.Object);
         }
 
-        [Fact, IsLayer0]
+        [Fact, IsDev]
         public async Task MergeIsInvoked()
         {
             var result = await _subscriberConfigurationLoader.LoadAsync();


### PR DESCRIPTION
This test needs a env variable configured with the KV to run. So excluding for now so we can satisfactorily run after CI deploy.