### PR TITLE
#75736 - explicitly close reader

### DIFF
--- a/src/CaptainHook.EventReaderService/EventReaderService.cs
+++ b/src/CaptainHook.EventReaderService/EventReaderService.cs
@@ -339,8 +339,11 @@ namespace CaptainHook.EventReaderService
 
             foreach (var item in list)
             {
-                //await item.Value.Receiver.CloseAsync(); 
-                _messageReceivers.Remove(item.Key, out _);
+                _messageReceivers.Remove(item.Key, out var receiverItem);
+                if (receiverItem?.Receiver != null)
+                {
+                    await receiverItem.Receiver.CloseAsync();
+                }
             }
         }
 


### PR DESCRIPTION
### What
Close reader explicitly

### Why
High number of `QuotaExceededException`s are thrown. The reader is now closed explicitly in the hope this is going to address the problem. Initial tests are positive. After having deployed to CI and TEST the exceptions have not appeared within 1h after the deploy.