### PR TITLE
Use temp config loader for API project

### DIFF
--- a/src/CaptainHook.Api/CaptainHook.Api.csproj
+++ b/src/CaptainHook.Api/CaptainHook.Api.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="4.0.470" />
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Eshopworld.DevOps" Version="5.0.1" />
     <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
     <PackageReference Include="Eshopworld.Web" Version="4.0.1" />
     <PackageReference Include="IdentityServer4" Version="4.0.1" />

--- a/src/CaptainHook.Api/PackageRoot/ServiceManifest.xml
+++ b/src/CaptainHook.Api/PackageRoot/ServiceManifest.xml
@@ -20,7 +20,7 @@
     </EntryPoint>
     <EnvironmentVariables>
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="Development"/>
-      <EnvironmentVariable Name="KEYVAULT_URL" Value="N/A" />
+      <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="N/A" />
     </EnvironmentVariables>
   </CodePackage>
 

--- a/src/CaptainHook.Api/Startup.cs
+++ b/src/CaptainHook.Api/Startup.cs
@@ -19,6 +19,7 @@ using Eshopworld.Telemetry.Processors;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.OpenApi.Models;
 using CaptainHook.Api.Helpers;
+using CaptainHook.Common.Configuration;
 
 namespace CaptainHook.Api
 {
@@ -35,10 +36,9 @@ namespace CaptainHook.Api
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="env">hosting environment</param>
-        public Startup(IWebHostEnvironment env)
-        {
-            _configuration = EswDevOpsSdk.BuildConfiguration(env.ContentRootPath, env.EnvironmentName);
+        public Startup()
+        {            
+            _configuration = TempConfigLoader.Load();
             _instrumentationKey = _configuration["InstrumentationKey"];
             _bb = BigBrother.CreateDefault(_instrumentationKey, _instrumentationKey);
         }

--- a/src/CaptainHook.Common/CaptainHook.Common.csproj
+++ b/src/CaptainHook.Common/CaptainHook.Common.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Autofac.ServiceFabric" Version="3.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
+    <PackageReference Include="Eshopworld.DevOps" Version="5.0.1" />
     <PackageReference Include="Eshopworld.Telemetry" Version="3.1.4" />
     <PackageReference Include="IdentityModel" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
   </ItemGroup>

--- a/src/CaptainHook.Common/Configuration/TempConfigLoader.cs
+++ b/src/CaptainHook.Common/Configuration/TempConfigLoader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Azure.Security.KeyVault.Secrets;
 using CaptainHook.Common.Configuration.KeyVault;
+using Eshopworld.DevOps;
 using Microsoft.Extensions.Configuration;
 
 namespace CaptainHook.Common.Configuration
@@ -37,6 +38,8 @@ namespace CaptainHook.Common.Configuration
             var builder = new ConfigurationBuilder ();
             return builder
                 .AddInMemoryCollection (entries)
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile($"appsettings.{EswDevOpsSdk.GetEnvironmentName()}.json", optional: true)
                 .AddEnvironmentVariables ()
                 .Build ();
         }

--- a/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/src/CaptainHook.Fabric/ApplicationPackageRoot/ApplicationManifest.xml
@@ -19,7 +19,7 @@
   <ServiceManifestImport>
     <ServiceManifestRef ServiceManifestName="CaptainHook.ApiPkg" ServiceManifestVersion="1.0.0" />
     <EnvironmentOverrides CodePackageRef="Code">
-      <EnvironmentVariable Name="KEYVAULT_URL" Value="[KeyVault_Base_Uri]" />
+      <EnvironmentVariable Name="KEYVAULT_BASE_URI" Value="[KeyVault_Base_Uri]" />
       <EnvironmentVariable Name="ASPNETCORE_ENVIRONMENT" Value="[AspNetCore_Environment]" />
     </EnvironmentOverrides>
   </ServiceManifestImport>


### PR DESCRIPTION
Use the TempConfigLoader in the API project to avoid loading the entire KV, in order to improve the API bootstrap time.
Also cleaned up some unused packages.