### PR TITLE
Task 75634 extend source config with replace option

### DIFF
--- a/src/CaptainHook.Benchmark/Program.cs
+++ b/src/CaptainHook.Benchmark/Program.cs
@@ -38,12 +38,12 @@ namespace CaptainHook.Benchmark
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation {Path = "OrderCode"},
+                        Source = new SourceParserLocation {Path = "OrderCode"},
                         Destination = new ParserLocation {Location = Location.Uri}
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation {Path = "BrandType"},
+                        Source = new SourceParserLocation {Path = "BrandType"},
                         Destination = new ParserLocation
                         {
                             RuleAction = RuleAction.Route
@@ -72,7 +72,7 @@ namespace CaptainHook.Benchmark
                             }
                         }
                     },
-                    new WebhookRequestRule {Source = new ParserLocation {Path = "OrderConfirmationRequestDto"}}
+                    new WebhookRequestRule {Source = new SourceParserLocation {Path = "OrderConfirmationRequestDto"}}
                 }
             };
 

--- a/src/CaptainHook.Cli/Commands/GenerateJson/GenerateJsonCommand.cs
+++ b/src/CaptainHook.Cli/Commands/GenerateJson/GenerateJsonCommand.cs
@@ -30,7 +30,7 @@ namespace CaptainHook.Cli.Commands.GenerateJson
             DefaultValueHandling = DefaultValueHandling.Ignore,
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             ContractResolver = new ShouldSerializeContractResolver(),
-            Converters = new List<JsonConverter> { new StringEnumConverter() }
+            Converters = { new StringEnumConverter() }
         };
 
         public GenerateJsonCommand(IFileSystem fileSystem)

--- a/src/CaptainHook.Cli/Common/ShouldSerializeContractResolver.cs
+++ b/src/CaptainHook.Cli/Common/ShouldSerializeContractResolver.cs
@@ -1,4 +1,5 @@
 ﻿using CaptainHook.Common.Authentication;
+using CaptainHook.Common.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
@@ -20,7 +21,9 @@ namespace CaptainHook.Cli.Common
             JsonProperty property = base.CreateProperty(member, memberSerialization);
 
             // don't serialize empty collections
-            if (property.PropertyType != typeof(string) && property.PropertyType.GetInterface(nameof(IEnumerable)) != null)
+            if (property.PropertyType != typeof(string) 
+                && property.PropertyType.GetInterface(nameof(IEnumerable)) != null 
+                && property.DeclaringType != typeof(SourceParserLocation))
             {
                 property.ShouldSerialize =
                     instance => (instance?.GetType().GetProperty(property.PropertyName).GetValue(instance) as IEnumerable<object>)?.Count() > 0;

--- a/src/CaptainHook.Cli/Common/ShouldSerializeContractResolver.cs
+++ b/src/CaptainHook.Cli/Common/ShouldSerializeContractResolver.cs
@@ -1,12 +1,10 @@
-﻿using CaptainHook.Common.Authentication;
-using CaptainHook.Common.Configuration;
+﻿using CaptainHook.Common.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Reflection;
 
 namespace CaptainHook.Cli.Common
@@ -20,10 +18,14 @@ namespace CaptainHook.Cli.Common
         {
             JsonProperty property = base.CreateProperty(member, memberSerialization);
 
+            // when declaring type is SourceParserLocation, serialize with default config
+            if (property.DeclaringType == typeof(SourceParserLocation))
+            {
+                return property;
+            }
+
             // don't serialize empty collections
-            if (property.PropertyType != typeof(string) 
-                && property.PropertyType.GetInterface(nameof(IEnumerable)) != null 
-                && property.DeclaringType != typeof(SourceParserLocation))
+            if (property.PropertyType != typeof(string) && property.PropertyType.GetInterface(nameof(IEnumerable)) != null)
             {
                 property.ShouldSerialize =
                     instance => (instance?.GetType().GetProperty(property.PropertyName).GetValue(instance) as IEnumerable<object>)?.Count() > 0;

--- a/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
+++ b/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
@@ -264,14 +264,14 @@ namespace CaptainHook.Common.Configuration
         public WebhookRequestRule()
         {
             Routes = new List<WebhookConfigRoute>();
-            Source = new ParserLocation();
+            Source = new SourceParserLocation();
             Destination = new ParserLocation();
         }
 
         /// <summary>
         /// ie from payload, header, etc etc
         /// </summary>
-        public ParserLocation Source { get; set; }
+        public SourceParserLocation Source { get; set; }
 
         /// <summary>
         /// ie uri, body, header
@@ -293,6 +293,7 @@ namespace CaptainHook.Common.Configuration
         public string Selector { get; set; }
     }
 
+    [KnownType(typeof(SourceParserLocation))]
     public class ParserLocation
     {
         /// <summary>

--- a/src/CaptainHook.Common/Configuration/SourceParserLocation.cs
+++ b/src/CaptainHook.Common/Configuration/SourceParserLocation.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace CaptainHook.Common.Configuration
+{
+    public class SourceParserLocation: ParserLocation
+    {
+        public IDictionary<string, string> Replace { get; set; }
+    }
+}

--- a/src/Tests/CaptainHook.Tests/Builders/WebhookRequestRuleBuilder.cs
+++ b/src/Tests/CaptainHook.Tests/Builders/WebhookRequestRuleBuilder.cs
@@ -7,13 +7,13 @@ namespace CaptainHook.Tests.Builders
 {
     internal class WebhookRequestRuleBuilder
     {
-        private ParserLocation _source;
+        private SourceParserLocation _source;
         private ParserLocation _destination;
         private List<WebhookConfigRoute> _routes;
 
         public WebhookRequestRuleBuilder WithSource(string path = null, DataType type = DataType.Property, Location location = Location.Body)
         {
-            _source = new ParserLocation
+            _source = new SourceParserLocation
             {
                 Path = path,
                 Location = location,

--- a/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
@@ -33,7 +33,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "OrderCode"
                                 },
@@ -117,7 +117,7 @@ namespace CaptainHook.Tests.Configuration
                             {
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "OrderCode"
                                     },
@@ -142,7 +142,7 @@ namespace CaptainHook.Tests.Configuration
                             {
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "OrderCode"
                                     },
@@ -153,7 +153,7 @@ namespace CaptainHook.Tests.Configuration
                                 },
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "BrandType"
                                     },
@@ -187,7 +187,7 @@ namespace CaptainHook.Tests.Configuration
                                 },
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "OrderConfirmationRequestDto"
                                     }
@@ -208,7 +208,7 @@ namespace CaptainHook.Tests.Configuration
                             {
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "OrderCode"
                                     },
@@ -219,7 +219,7 @@ namespace CaptainHook.Tests.Configuration
                                 },
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "BrandType"
                                     },
@@ -266,7 +266,7 @@ namespace CaptainHook.Tests.Configuration
                             {
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "BrandType"
                                     },
@@ -319,7 +319,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "InnerModel"
                                 },
@@ -346,7 +346,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "InnerModel"
                                 },
@@ -358,7 +358,7 @@ namespace CaptainHook.Tests.Configuration
                             },
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "OrderCode"
                                 },
@@ -385,7 +385,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "OrderCode"
                                 },
@@ -396,7 +396,7 @@ namespace CaptainHook.Tests.Configuration
                             },
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Type = DataType.HttpStatusCode,
                                     Location = Location.HttpStatusCode
@@ -409,7 +409,7 @@ namespace CaptainHook.Tests.Configuration
                             },
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Type = DataType.HttpContent
                                 },
@@ -436,7 +436,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "InnerModel"
                                 },
@@ -467,7 +467,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "OrderCode"
                                 },
@@ -492,7 +492,7 @@ namespace CaptainHook.Tests.Configuration
                             {
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "OrderCode"
                                     },
@@ -503,7 +503,7 @@ namespace CaptainHook.Tests.Configuration
                                 },
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "BrandType"
                                     },
@@ -556,7 +556,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "OrderCode"
                                 },
@@ -582,7 +582,7 @@ namespace CaptainHook.Tests.Configuration
                         {
                             new WebhookRequestRule
                             {
-                                Source = new ParserLocation
+                                Source = new SourceParserLocation
                                 {
                                     Path = "OrderCode"
                                 },
@@ -608,7 +608,7 @@ namespace CaptainHook.Tests.Configuration
                             {
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "OrderCode"
                                     },
@@ -619,7 +619,7 @@ namespace CaptainHook.Tests.Configuration
                                 },
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "BrandType"
                                     },
@@ -667,7 +667,7 @@ namespace CaptainHook.Tests.Configuration
                             {
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "OrderCode"
                                     },
@@ -678,7 +678,7 @@ namespace CaptainHook.Tests.Configuration
                                 },
                                 new WebhookRequestRule
                                 {
-                                    Source = new ParserLocation
+                                    Source = new SourceParserLocation
                                     {
                                         Path = "BrandType"
                                     },

--- a/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
@@ -64,6 +64,16 @@ namespace CaptainHook.Tests.Configuration
         }
 
         [IsUnit]
+        [Theory(Skip = "Not implemented yet")]
+        [MemberData(nameof(UriData_RouteAndReplace))]
+        public void UriConstructionRouteAndReplaceTests(WebhookConfig config, string payload, string expectedUri)
+        {
+            var uri = new RequestBuilder(Mock.Of<IBigBrother>()).BuildUri(config, payload);
+
+            Assert.Equal(new Uri(expectedUri), uri);
+        }
+
+        [IsUnit]
         [Theory]
         [MemberData(nameof(PayloadData))]
         public void PayloadConstructionTests(
@@ -302,6 +312,121 @@ namespace CaptainHook.Tests.Configuration
                         },
                     "{\"OrderCode\":\"9744b831-df2c-4d59-9d9d-691f4121f73a\", \"BrandType\":\"Brand2\"}",
                     "https://blah.blah.brand3.eshopworld.com/webhook"
+                },
+            };
+
+        public static IEnumerable<object[]> UriData_RouteAndReplace =>
+            new List<object[]>
+            {
+                new object[]
+                {
+                    new WebhookConfig
+                        {
+                            Name = "Webhook1",
+                            WebhookRequestRules = new List<WebhookRequestRule>
+                            {
+                                new WebhookRequestRule
+                                {
+                                    Source = new SourceParserLocation
+                                    {
+                                        Replace = new Dictionary<string, string>
+                                        {
+                                            { "selector",  "$.TenantCode"},
+                                            { "orderCode",  "$.OrderCode"}
+                                        }
+                                    },
+                                    Destination = new ParserLocation
+                                    {
+                                        RuleAction = RuleAction.Route
+                                    },
+                                    Routes = new List<WebhookConfigRoute>
+                                    {
+                                        new WebhookConfigRoute
+                                        {
+                                            Uri = "https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}",
+                                            HttpMethod = HttpMethod.Post,
+                                            Selector = "Brand1",
+                                            AuthenticationConfig = new AuthenticationConfig
+                                            {
+                                                Type = AuthenticationType.None
+                                            }
+                                        },
+                                        new WebhookConfigRoute
+                                        {
+                                            Uri = "https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}",
+                                            HttpMethod = HttpMethod.Put,
+                                            Selector = "Brand2",
+                                            AuthenticationConfig = new AuthenticationConfig
+                                            {
+                                                Type = AuthenticationType.None
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    "{\"OrderCode\":\"9744b831-df2c-4d59-9d9d-691f4121f73a\", \"BrandType\":\"Brand2\", \"TenantCode\":\"tenant1\"}",
+                    "https://blah.blah.tenant1.eshopworld.com/webhook/9744b831-df2c-4d59-9d9d-691f4121f73a"
+                },
+                new object[]
+                {
+                    new WebhookConfig
+                    {
+                        Name = "Webhook2",
+                        WebhookRequestRules = new List<WebhookRequestRule>
+                        {
+                            new WebhookRequestRule
+                            {
+                                Source = new SourceParserLocation
+                                {
+                                    Replace = new Dictionary<string, string>
+                                    {
+                                        { "selector",  "$.TenantCode"},
+                                        { "orderCode",  "$.OrderCode"}
+                                    }
+                                }
+                            }
+                        },
+                        Uri = "https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}",
+                        HttpMethod = HttpMethod.Post,
+                        AuthenticationConfig = new AuthenticationConfig
+                        {
+                            Type = AuthenticationType.None
+                        }
+
+                    },
+                    "{\"OrderCode\":\"9744b831-df2c-4d59-9d9d-691f4121f73a\", \"BrandType\":\"Brand2\", \"TenantCode\":\"tenant1\"}",
+                    "https://blah.blah.tenant1.eshopworld.com/webhook/9744b831-df2c-4d59-9d9d-691f4121f73a"
+                },
+                new object[]
+                {
+                    new WebhookConfig
+                    {
+                        Name = "Webhook3",
+                        WebhookRequestRules = new List<WebhookRequestRule>
+                        {
+                            new WebhookRequestRule
+                            {
+                                Source = new SourceParserLocation
+                                {
+                                    Replace = new Dictionary<string, string>
+                                    {
+                                        { "selector",  "$.TenantCode"},
+                                        { "orderCode",  "$.OrderCode"}
+                                    }
+                                }
+                            }
+                        },
+                        Uri = "https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}",
+                        HttpMethod = HttpMethod.Post,
+                        AuthenticationConfig = new AuthenticationConfig
+                        {
+                            Type = AuthenticationType.None
+                        }
+
+                    },
+                    "{\"OrderCode\":\"DEV13:00026804\", \"BrandType\":\"Brand2\", \"TenantCode\":\"tenant1\"}",
+                    "https://blah.blah.tenant1.eshopworld.com/webhook/DEV13%3A00026804"
                 }
             };
 

--- a/src/Tests/CaptainHook.Tests/Services/MessageDataSerializationTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/MessageDataSerializationTests.cs
@@ -47,7 +47,7 @@ namespace CaptainHook.Tests.Services
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "ActivityConfirmationRequestDto",
                             Type = DataType.Model
@@ -59,7 +59,7 @@ namespace CaptainHook.Tests.Services
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "TenantCode"
                         },

--- a/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
@@ -36,7 +36,7 @@ namespace CaptainHook.Tests.Services.Reliable
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "ActivityConfirmationRequestDto",
                             Type = DataType.Model
@@ -48,7 +48,7 @@ namespace CaptainHook.Tests.Services.Reliable
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "TenantCode"
                         },

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebhookHandlerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebhookHandlerTests.cs
@@ -49,7 +49,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                    new WebhookRequestRule
                    {
-                       Source = new ParserLocation
+                       Source = new SourceParserLocation
                        {
                            Path = "OrderCode"
                        },
@@ -103,7 +103,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                    new WebhookRequestRule
                    {
-                       Source = new ParserLocation
+                       Source = new SourceParserLocation
                        {
                            Path = "OrderCode"
                        },
@@ -160,7 +160,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                    new WebhookRequestRule
                    {
-                       Source = new ParserLocation
+                       Source = new SourceParserLocation
                        {
                            Path = "OrderCode"
                        },

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/WebhookResponseHandlerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/WebhookResponseHandlerTests.cs
@@ -361,7 +361,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "OrderCode"
                         },
@@ -372,7 +372,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "TransportModel",
                             Type = DataType.Model
@@ -398,7 +398,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "OrderCode"
                         },
@@ -410,7 +410,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Type = DataType.HttpStatusCode
                         },
@@ -421,7 +421,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Type = DataType.HttpContent
                         },
@@ -443,7 +443,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "OrderCode"
                         },
@@ -454,7 +454,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "BrandType"
                         },
@@ -478,7 +478,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "TransportModel",
                             Type = DataType.Model
@@ -504,7 +504,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "OrderCode"
                         },
@@ -515,7 +515,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Type = DataType.HttpStatusCode
                         },
@@ -526,7 +526,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Type = DataType.HttpContent
                         },
@@ -562,7 +562,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "OrderCode"
                         },
@@ -573,7 +573,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "BrandType"
                         },
@@ -597,7 +597,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "TransportModel",
                             Type = DataType.Model
@@ -624,7 +624,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                 {
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Path = "OrderCode"
                         },
@@ -636,7 +636,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Type = DataType.HttpStatusCode,
                         },
@@ -647,7 +647,7 @@ namespace CaptainHook.Tests.Web.WebHooks
                     },
                     new WebhookRequestRule
                     {
-                        Source = new ParserLocation
+                        Source = new SourceParserLocation
                         {
                             Type = DataType.HttpContent
                         },


### PR DESCRIPTION
### What
Parser Location is extended to facilitate a collection of Replace entries

### Why
We want to be able to extend CH with Replace transformation without affecting the existing code. New class to handle Source is created.

### Examples
Json entry:

```json
      {
        "Source": {
          "Replace": {
            "ordercode": "$.OrderCode",
            "selector": "$.TenantCode"
          }
        },
        "Destination": {
          "RuleAction": "Route"
        },
        "Routes": [
          {...
```
Powershell
```ps1
setConfig 'event--26--webhookconfig--webhookrequestrules--2--source--replace--selector' '$.TenantCode' $KeyVault
setConfig 'event--26--webhookconfig--webhookrequestrules--2--source--replace--ordercode' '$.OrderCode' $KeyVault
```