### PR TITLE
#75635 - add request builder for Route and Replace

### DIFF
--- a/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
+++ b/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
@@ -334,7 +334,8 @@ namespace CaptainHook.Common.Configuration
     {
         Replace = 1,
         Add = 2,
-        Route = 3
+        Route = 3,
+        RouteAndReplace = 4
     }
 
     public enum Location

--- a/src/CaptainHook.EventHandlerActor/HandlerModule.cs
+++ b/src/CaptainHook.EventHandlerActor/HandlerModule.cs
@@ -1,0 +1,23 @@
+﻿using Autofac;
+using CaptainHook.Common.Configuration;
+using CaptainHook.EventHandlerActor.Handlers;
+using CaptainHook.EventHandlerActor.Handlers.Authentication;
+using CaptainHook.EventHandlerActor.Handlers.Requests;
+
+namespace CaptainHook.EventHandlerActor
+{
+    public class HandlerModule: Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<DefaultRequestBuilder>().Keyed<IRequestBuilder>(RuleAction.Route);
+            builder.RegisterType<RouteAndReplaceRequestBuilder>().Keyed<IRequestBuilder>(RuleAction.RouteAndReplace);
+            builder.RegisterType<RequestBuilderDispatcher>().As<IRequestBuilder>();
+
+            builder.RegisterType<EventHandlerFactory>().As<IEventHandlerFactory>().SingleInstance();
+            builder.RegisterType<AuthenticationHandlerFactory>().As<IAuthenticationHandlerFactory>().SingleInstance();
+            builder.RegisterType<HttpClientFactory>().As<IHttpClientFactory>();
+            builder.RegisterType<RequestLogger>().As<IRequestLogger>();
+        }
+    }
+}

--- a/src/CaptainHook.EventHandlerActor/Handlers/Requests/DefaultRequestBuilder.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Requests/DefaultRequestBuilder.cs
@@ -10,13 +10,13 @@ using Eshopworld.Platform.Messages;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace CaptainHook.EventHandlerActor.Handlers
+namespace CaptainHook.EventHandlerActor.Handlers.Requests
 {
-    public class RequestBuilder : IRequestBuilder
+    public class DefaultRequestBuilder : IRequestBuilder
     {
         private readonly IBigBrother bb;
 
-        public RequestBuilder(IBigBrother _bb)
+        public DefaultRequestBuilder(IBigBrother _bb)
         {
             bb = _bb;
         }
@@ -25,7 +25,11 @@ namespace CaptainHook.EventHandlerActor.Handlers
         public Uri BuildUri(WebhookConfig config, string payload)
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
+            return BuildUriFromExistingConfig(config, payload);
+        }
 
+        protected virtual Uri BuildUriFromExistingConfig(WebhookConfig config, string payload)
+        {
             var uri = config.Uri;
 
             //build the uri from the routes first
@@ -44,7 +48,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 }
                 if (string.IsNullOrWhiteSpace(selector))
                 {
-                    PublishUnrouatableEvent("routing path value in message payload is null or empty" );
+                    PublishUnrouatableEvent("routing path value in message payload is null or empty");
                     return null;
                 }
 

--- a/src/CaptainHook.EventHandlerActor/Handlers/Requests/RequestBuilderDispatcher.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Requests/RequestBuilderDispatcher.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Autofac.Features.Indexed;
+using CaptainHook.Common;
+using CaptainHook.Common.Configuration;
+
+namespace CaptainHook.EventHandlerActor.Handlers.Requests
+{
+    public class RequestBuilderDispatcher: IRequestBuilder
+    {
+        private const RuleAction DefaultRoute = RuleAction.Route;
+
+        private readonly IIndex<RuleAction, IRequestBuilder> _requestBuilderIndex;
+
+        public RequestBuilderDispatcher(IIndex<RuleAction, IRequestBuilder> requestBuilderIndex)
+        {
+            _requestBuilderIndex = requestBuilderIndex;
+        }
+
+        private IRequestBuilder PickRequestBuilder(WebhookConfig config)
+        {
+            var hasRouteAndReplace = config.WebhookRequestRules.Any(r => r.Destination.RuleAction == RuleAction.RouteAndReplace);
+            return hasRouteAndReplace
+                ? _requestBuilderIndex[RuleAction.RouteAndReplace]
+                : _requestBuilderIndex[DefaultRoute];
+        }
+
+        public Uri BuildUri(WebhookConfig config, string payload) => PickRequestBuilder(config).BuildUri(config, payload);
+
+        public string BuildPayload(WebhookConfig config, string sourcePayload, IDictionary<string, object> data = null) 
+            => PickRequestBuilder(config).BuildPayload(config, sourcePayload, data);
+
+        public HttpMethod SelectHttpMethod(WebhookConfig webhookConfig, string payload) =>
+            PickRequestBuilder(webhookConfig).SelectHttpMethod(webhookConfig, payload);
+
+        public WebhookConfig GetAuthenticationConfig(WebhookConfig webhookConfig, string payload) =>
+            PickRequestBuilder(webhookConfig).GetAuthenticationConfig(webhookConfig, payload);
+
+        public WebhookConfig SelectWebhookConfig(WebhookConfig webhookConfig, string payload) =>
+            PickRequestBuilder(webhookConfig).SelectWebhookConfig(webhookConfig, payload);
+
+        public WebHookHeaders GetHttpHeaders(WebhookConfig webhookConfig, MessageData messageData) =>
+            PickRequestBuilder(webhookConfig).GetHttpHeaders(webhookConfig, messageData);
+    }
+}

--- a/src/CaptainHook.EventHandlerActor/Handlers/Requests/RouteAndReplaceRequestBuilder.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Requests/RouteAndReplaceRequestBuilder.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+using CaptainHook.Common.Configuration;
+using Eshopworld.Core;
+
+namespace CaptainHook.EventHandlerActor.Handlers.Requests
+{
+    public class RouteAndReplaceRequestBuilder: DefaultRequestBuilder
+    {
+        public RouteAndReplaceRequestBuilder(IBigBrother bigBrother): base(bigBrother)
+        {
+        }
+
+        protected override Uri BuildUriFromExistingConfig(WebhookConfig config, string payload)
+        {
+            var routeAndReplaceRule = config.WebhookRequestRules.FirstOrDefault(r => r.Destination.RuleAction == RuleAction.RouteAndReplace);
+            if (routeAndReplaceRule != null)
+            {
+                return null;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/CaptainHook.EventHandlerActor/Program.cs
+++ b/src/CaptainHook.EventHandlerActor/Program.cs
@@ -7,6 +7,7 @@ using CaptainHook.Common.Configuration;
 using CaptainHook.Common.Telemetry;
 using CaptainHook.EventHandlerActor.Handlers;
 using CaptainHook.EventHandlerActor.Handlers.Authentication;
+using CaptainHook.EventHandlerActor.Handlers.Requests;
 using Eshopworld.Telemetry;
 using Microsoft.Extensions.Configuration;
 
@@ -30,14 +31,9 @@ namespace CaptainHook.EventHandlerActor
 
                 builder.RegisterInstance(configurationSettings)
                     .SingleInstance();
-
-                builder.RegisterType<EventHandlerFactory>().As<IEventHandlerFactory>().SingleInstance();
-                builder.RegisterType<AuthenticationHandlerFactory>().As<IAuthenticationHandlerFactory>().SingleInstance();
-                builder.RegisterType<HttpClientFactory>().As<IHttpClientFactory>();
-                builder.RegisterType<RequestLogger>().As<IRequestLogger>();
-                builder.RegisterType<RequestBuilder>().As<IRequestBuilder>();
-
                 builder.RegisterActor<EventHandlerActor>();
+
+                builder.RegisterModule<HandlerModule>();
 
                 using (builder.Build())
                 {

--- a/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
@@ -5,6 +5,7 @@ using CaptainHook.Common;
 using CaptainHook.Common.Authentication;
 using CaptainHook.Common.Configuration;
 using CaptainHook.EventHandlerActor.Handlers;
+using CaptainHook.EventHandlerActor.Handlers.Requests;
 using Eshopworld.Core;
 using Eshopworld.Tests.Core;
 using Moq;
@@ -49,7 +50,7 @@ namespace CaptainHook.Tests.Configuration
 
             var messageData = new MessageData("blah", "blahtype", "blahsubscriber", "blahReplyTo", false) { ServiceBusMessageId = Guid.NewGuid().ToString(), CorrelationId = Guid.NewGuid().ToString() };
 
-            var headers = new RequestBuilder(Mock.Of<IBigBrother>()).GetHttpHeaders(config, messageData);
+            var headers = new DefaultRequestBuilder(Mock.Of<IBigBrother>()).GetHttpHeaders(config, messageData);
             Assert.True(headers.RequestHeaders.ContainsKey(Constants.Headers.IdempotencyKey));
         }
 
@@ -58,7 +59,7 @@ namespace CaptainHook.Tests.Configuration
         [MemberData(nameof(UriData))]
         public void UriConstructionTests(WebhookConfig config, string payload, string expectedUri)
         {
-            var uri = new RequestBuilder(Mock.Of<IBigBrother>()).BuildUri(config, payload);
+            var uri = new DefaultRequestBuilder(Mock.Of<IBigBrother>()).BuildUri(config, payload);
 
             Assert.Equal(new Uri(expectedUri), uri);
         }
@@ -72,7 +73,7 @@ namespace CaptainHook.Tests.Configuration
             Dictionary<string, object> data,
             string expectedPayload)
         {
-            var requestPayload = new RequestBuilder(Mock.Of<IBigBrother>()).BuildPayload(config, sourcePayload, data);
+            var requestPayload = new DefaultRequestBuilder(Mock.Of<IBigBrother>()).BuildPayload(config, sourcePayload, data);
 
             Assert.Equal(expectedPayload, requestPayload);
         }
@@ -85,7 +86,7 @@ namespace CaptainHook.Tests.Configuration
             string sourcePayload,
             HttpMethod expectedVerb)
         {
-            var selectedVerb = new RequestBuilder(Mock.Of<IBigBrother>()).SelectHttpMethod(config, sourcePayload);
+            var selectedVerb = new DefaultRequestBuilder(Mock.Of<IBigBrother>()).SelectHttpMethod(config, sourcePayload);
 
             Assert.Equal(expectedVerb, selectedVerb);
         }
@@ -98,7 +99,7 @@ namespace CaptainHook.Tests.Configuration
             string sourcePayload,
             AuthenticationType expectedAuthenticationType)
         {
-            var authenticationConfig = new RequestBuilder(Mock.Of<IBigBrother>()).GetAuthenticationConfig(config, sourcePayload);
+            var authenticationConfig = new DefaultRequestBuilder(Mock.Of<IBigBrother>()).GetAuthenticationConfig(config, sourcePayload);
 
             Assert.Equal(expectedAuthenticationType, authenticationConfig.AuthenticationConfig.Type);
         }

--- a/src/Tests/CaptainHook.Tests/Services/Actors/Requests/RequestBuilderDispatcherTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Actors/Requests/RequestBuilderDispatcherTests.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using Autofac.Features.Indexed;
+using CaptainHook.Common.Configuration;
+using CaptainHook.EventHandlerActor.Handlers;
+using CaptainHook.EventHandlerActor.Handlers.Requests;
+using Eshopworld.Tests.Core;
+using Moq;
+using Xunit;
+
+namespace CaptainHook.Tests.Services.Actors.Requests
+{
+    public class RequestBuilderDispatcherTests
+    {
+        private readonly Mock<IRequestBuilder> _routeAndReplaceBuilder;
+        private readonly Mock<IRequestBuilder> _defaultBuilder;
+        private readonly RequestBuilderDispatcher _requestBuilderDispatcher;
+
+        public RequestBuilderDispatcherTests()
+        {
+            _routeAndReplaceBuilder = new Mock<IRequestBuilder>();
+            _defaultBuilder = new Mock<IRequestBuilder>();
+
+            var indexMock = new Mock<IIndex<RuleAction, IRequestBuilder>>();
+            indexMock.Setup(x => x[RuleAction.RouteAndReplace]).Returns(_routeAndReplaceBuilder.Object);
+            indexMock.Setup(x => x[RuleAction.Route]).Returns(_defaultBuilder.Object);
+
+            _requestBuilderDispatcher = new RequestBuilderDispatcher(indexMock.Object);
+        }
+
+        [Fact, IsUnit]
+        public void BuildUri_ExecutesRouteAndReplace_WhenRouteAndReplaceConfig()
+        {
+            // Arrange
+            var routeAndReplaceConfig = BuildConfig(RuleAction.RouteAndReplace);
+
+            // Act
+            _requestBuilderDispatcher.BuildUri(routeAndReplaceConfig, "dummy-payload");
+
+            // Assert
+            _routeAndReplaceBuilder.Verify(b => b.BuildUri(routeAndReplaceConfig, "dummy-payload"), Times.Once);
+            _defaultBuilder.Verify(b => b.BuildUri(It.IsAny<WebhookConfig>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Theory, IsUnit]
+        [InlineData(RuleAction.Route)]
+        [InlineData(RuleAction.Add)]
+        [InlineData(RuleAction.Replace)]
+        public void BuildUri_ExecutesRoute_WhenRouteConfig(RuleAction ruleAction)
+        {
+            // Arrange
+            var routeConfig = BuildConfig(ruleAction);
+
+            // Act
+            _requestBuilderDispatcher.BuildUri(routeConfig, "dummy-payload");
+
+            // Assert
+            _defaultBuilder.Verify(b => b.BuildUri(routeConfig, "dummy-payload"), Times.Once);
+            _routeAndReplaceBuilder.Verify(b => b.BuildUri(It.IsAny<WebhookConfig>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact, IsUnit]
+        public void GetAuthenticationConfig_ExecutesRouteAndReplace_WhenRouteAndReplaceConfig()
+        {
+            // Arrange
+            var routeAndReplaceConfig = BuildConfig(RuleAction.RouteAndReplace);
+
+            // Act
+            _requestBuilderDispatcher.GetAuthenticationConfig(routeAndReplaceConfig, "dummy-payload");
+
+            // Assert
+            _routeAndReplaceBuilder.Verify(b => b.GetAuthenticationConfig(routeAndReplaceConfig, "dummy-payload"), Times.Once);
+            _defaultBuilder.Verify(b => b.GetAuthenticationConfig(It.IsAny<WebhookConfig>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Theory, IsUnit]
+        [InlineData(RuleAction.Route)]
+        [InlineData(RuleAction.Add)]
+        [InlineData(RuleAction.Replace)]
+        public void GetAuthenticationConfig_ExecutesRoute_WhenRouteConfig(RuleAction ruleAction)
+        {
+            // Arrange
+            var routeConfig = BuildConfig(ruleAction);
+
+            // Act
+            _requestBuilderDispatcher.GetAuthenticationConfig(routeConfig, "dummy-payload");
+
+            // Assert
+            _defaultBuilder.Verify(b => b.GetAuthenticationConfig(routeConfig, "dummy-payload"), Times.Once);
+            _routeAndReplaceBuilder.Verify(b => b.GetAuthenticationConfig(It.IsAny<WebhookConfig>(), It.IsAny<string>()), Times.Never);
+        }
+
+        private static WebhookConfig BuildConfig(RuleAction ruleAction) => new WebhookConfig
+        {
+            WebhookRequestRules =
+                new List<WebhookRequestRule>
+                {
+                    new WebhookRequestRule
+                    {
+                        Destination =
+                        {
+                            RuleAction = ruleAction
+                        },
+                        Source =
+                        {
+                            Replace = new Dictionary<string, string>
+                            {
+                                { "key", "value" }
+                            }
+                        }
+                    }
+                }
+        };
+    }
+}

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebHookHandlerVerbTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebHookHandlerVerbTests.cs
@@ -8,6 +8,7 @@ using CaptainHook.Common;
 using CaptainHook.Common.Configuration;
 using CaptainHook.EventHandlerActor.Handlers;
 using CaptainHook.EventHandlerActor.Handlers.Authentication;
+using CaptainHook.EventHandlerActor.Handlers.Requests;
 using CaptainHook.Tests.Web.Authentication;
 using Eshopworld.Core;
 using Eshopworld.Tests.Core;
@@ -46,7 +47,7 @@ namespace CaptainHook.Tests.Web.WebHooks
             var mockAuthenticationFactory = new Mock<IAuthenticationHandlerFactory>();
 
             var httpClientBuilder = new HttpClientFactory(httpClients);
-            var requestBuilder = new RequestBuilder(Mock.Of<IBigBrother>());
+            var requestBuilder = new DefaultRequestBuilder(Mock.Of<IBigBrother>());
             var requestLogger = new RequestLogger(mockBigBrother.Object);
 
             var genericWebhookHandler = new GenericWebhookHandler(
@@ -74,7 +75,7 @@ namespace CaptainHook.Tests.Web.WebHooks
             var httpClients = new Dictionary<string, HttpClient> { { new Uri(config.Uri).Host, mockHttp.ToHttpClient() } };
 
             var httpClientBuilder = new HttpClientFactory(httpClients);
-            var requestBuilder = new RequestBuilder(Mock.Of<IBigBrother>());
+            var requestBuilder = new DefaultRequestBuilder(Mock.Of<IBigBrother>());
             var requestLogger = new RequestLogger(mockBigBrother.Object);
 
             var genericWebhookHandler = new GenericWebhookHandler(

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebhookHandlerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebhookHandlerTests.cs
@@ -10,6 +10,7 @@ using CaptainHook.Common.Authentication;
 using CaptainHook.Common.Configuration;
 using CaptainHook.EventHandlerActor.Handlers;
 using CaptainHook.EventHandlerActor.Handlers.Authentication;
+using CaptainHook.EventHandlerActor.Handlers.Requests;
 using CaptainHook.Tests.Web.Authentication;
 using Eshopworld.Core;
 using Eshopworld.Platform.Messages;
@@ -70,7 +71,7 @@ namespace CaptainHook.Tests.Web.WebHooks
             var httpClients = new Dictionary<string, HttpClient> { { new Uri(config.Uri).Host, mockHttp.ToHttpClient() } };
 
             var httpClientBuilder = new HttpClientFactory(httpClients);
-            var requestBuilder = new RequestBuilder(Mock.Of<IBigBrother>());
+            var requestBuilder = new DefaultRequestBuilder(Mock.Of<IBigBrother>());
             var requestLogger = new RequestLogger(mockBigBrother.Object);
 
             var genericWebhookHandler = new GenericWebhookHandler(
@@ -124,7 +125,7 @@ namespace CaptainHook.Tests.Web.WebHooks
             var httpClients = new Dictionary<string, HttpClient> { { new Uri(config.Uri).Host, mockHttp.ToHttpClient() } };
 
             var httpClientBuilder = new HttpClientFactory(httpClients);
-            var requestBuilder = new RequestBuilder(Mock.Of<IBigBrother>());
+            var requestBuilder = new DefaultRequestBuilder(Mock.Of<IBigBrother>());
             var requestLogger = new RequestLogger(mockBigBrother.Object);
 
             var genericWebhookHandler = new GenericWebhookHandler(
@@ -198,7 +199,7 @@ namespace CaptainHook.Tests.Web.WebHooks
             var httpClients = new Dictionary<string, HttpClient> { { new Uri(config.Uri).Host, mockHttp.ToHttpClient() } };
 
             var httpClientBuilder = new HttpClientFactory(httpClients);
-            var requestBuilder = new RequestBuilder(Mock.Of<IBigBrother>());
+            var requestBuilder = new DefaultRequestBuilder(Mock.Of<IBigBrother>());
             var requestLogger = new RequestLogger(mockBigBrother.Object);
 
             var genericWebhookHandler = new GenericWebhookHandler(

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/WebhookResponseHandlerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/WebhookResponseHandlerTests.cs
@@ -11,6 +11,7 @@ using CaptainHook.Common.Configuration;
 using CaptainHook.Common.Telemetry.Message;
 using CaptainHook.EventHandlerActor.Handlers;
 using CaptainHook.EventHandlerActor.Handlers.Authentication;
+using CaptainHook.EventHandlerActor.Handlers.Requests;
 using CaptainHook.Tests.Web.Authentication;
 using Eshopworld.Core;
 using Eshopworld.Tests.Core;
@@ -52,7 +53,7 @@ namespace CaptainHook.Tests.Web.WebHooks
             Mock<IAuthenticationHandlerFactory> mockAuthHandlerFactory)
         {
             var httpClientBuilder = new HttpClientFactory(httpClients);
-            var requestBuilder = new RequestBuilder(mockBigBrother.Object);
+            var requestBuilder = new DefaultRequestBuilder(mockBigBrother.Object);
             var requestLogger = new RequestLogger(mockBigBrother.Object);
             var handlerFactory = new EventHandlerFactory(mockBigBrother.Object, 
                 httpClientBuilder, mockAuthHandlerFactory.Object, requestLogger, requestBuilder);


### PR DESCRIPTION
### What
Introduces a backbone to implement the logic for request builder where RouteAndReplace mechanism is going to be used. Logic itself is yet to be implemented.

### Classes
1. DefaultRequestBuilder (renamed from RequestBuilder) is the previous implementation of the builder
2. RequestBuilderDispatcher decides which builder to use
3. RouteAndReplaceRequestBuilder is the backbone for the new request builder for Route and Replace. Yet to be implemented fully.

