### PR TITLE
Escape URI parameter from payload

### DIFF
--- a/src/CaptainHook.EventHandlerActor/Handlers/RequestBuilder.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/RequestBuilder.cs
@@ -38,13 +38,13 @@ namespace CaptainHook.EventHandlerActor.Handlers
                     selector = ModelParser.ParsePayloadPropertyAsString(rules.Source.Path, payload);
                 }
 
-                void PublishUnrouatableEvent(string message)
+                void PublishUnroutableEvent(string message)
                 {
                     bb.Publish(new UnroutableMessageEvent { EventType = config.EventType, Selector = selector, SubscriberName = config.Name, Message = message });
                 }
                 if (string.IsNullOrWhiteSpace(selector))
                 {
-                    PublishUnrouatableEvent("routing path value in message payload is null or empty" );
+                    PublishUnroutableEvent("routing path value in message payload is null or empty" );
                     return null;
                 }
 
@@ -52,7 +52,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 var route = rules.Routes.FirstOrDefault(r => r.Selector.Equals(selector, StringComparison.OrdinalIgnoreCase));
                 if (route == null)
                 {
-                    PublishUnrouatableEvent("route mapping/selector not found between config and the properties on the domain object");
+                    PublishUnroutableEvent("route mapping/selector not found between config and the properties on the domain object");
                     return null;
                 }
                 uri = route.Uri;
@@ -84,7 +84,8 @@ namespace CaptainHook.EventHandlerActor.Handlers
         private static string CombineUriAndResourceId(string uri, string parameter)
         {
             var position = uri.LastIndexOfSafe('/');
-            uri = position == uri.Length - 1 ? $"{uri}{parameter}" : $"{uri}/{parameter}";
+            var encodedParameter = Uri.EscapeDataString(parameter);
+            uri = position == uri.Length - 1 ? $"{uri}{encodedParameter}" : $"{uri}/{encodedParameter}";
             return uri;
         }
 

--- a/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Configuration/RequestBuilderTests.cs
@@ -302,6 +302,72 @@ namespace CaptainHook.Tests.Configuration
                         },
                     "{\"OrderCode\":\"9744b831-df2c-4d59-9d9d-691f4121f73a\", \"BrandType\":\"Brand2\"}",
                     "https://blah.blah.brand3.eshopworld.com/webhook"
+                },
+                new object[]
+                {
+                    new WebhookConfig
+                        {
+                            Name = "Webhook5",
+                            HttpMethod = HttpMethod.Post,
+                            Uri = "https://blah.blah.eshopworld.com/webhook/",
+                            WebhookRequestRules = new List<WebhookRequestRule>
+                            {
+                                new WebhookRequestRule
+                                {
+                                    Source = new ParserLocation
+                                    {
+                                        Path = "OrderCode"
+                                    },
+                                    Destination = new ParserLocation
+                                    {
+                                        Location = Location.Uri
+                                    }
+                                },
+                                new WebhookRequestRule
+                                {
+                                    Source = new ParserLocation
+                                    {
+                                        Path = "BrandType"
+                                    },
+                                    Destination = new ParserLocation
+                                    {
+                                        RuleAction = RuleAction.Route
+                                    },
+                                    Routes = new List<WebhookConfigRoute>
+                                    {
+                                        new WebhookConfigRoute
+                                        {
+                                            Uri = "https://blah.blah.brand1.eshopworld.com/webhook",
+                                            HttpMethod = HttpMethod.Post,
+                                            Selector = "Brand1",
+                                            AuthenticationConfig = new AuthenticationConfig
+                                            {
+                                                Type = AuthenticationType.None
+                                            }
+                                        },
+                                        new WebhookConfigRoute
+                                        {
+                                            Uri = "https://blah.blah.brand2.eshopworld.com/webhook",
+                                            HttpMethod = HttpMethod.Put,
+                                            Selector = "Brand2",
+                                            AuthenticationConfig = new AuthenticationConfig
+                                            {
+                                                Type = AuthenticationType.None
+                                            }
+                                        }
+                                    }
+                                },
+                                new WebhookRequestRule
+                                {
+                                    Source = new ParserLocation
+                                    {
+                                        Path = "OrderConfirmationRequestDto"
+                                    }
+                                }
+                            }
+                        },
+                    "{\"OrderCode\":\"DEV13:00026804\", \"BrandType\":\"Brand1\"}",
+                    "https://blah.blah.brand1.eshopworld.com/webhook/DEV13%3A00026804"
                 }
             };
 


### PR DESCRIPTION
The URI builder will produce an invalid URI if the payload parameter is not URI safe. Therefore the HTTP call will most likely fail at the other end.

This PR addresses the issue by encoding any parameter appended at the end of the URI.