### PR TITLE
Use DefaultAzureCredential for Azure auth for KV loading

### DIFF
--- a/src/CaptainHook.Common/Configuration/KeyVault/KeyVaultModule.cs
+++ b/src/CaptainHook.Common/Configuration/KeyVault/KeyVaultModule.cs
@@ -3,26 +3,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Azure.Core;
+using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Azure.Services.AppAuthentication;
 using TokenCredential = Azure.Core.TokenCredential;
 
 namespace CaptainHook.Common.Configuration.KeyVault
 {
-    internal class AzureServiceTokenCredential : TokenCredential
-    {
-        public override async ValueTask<AccessToken> GetTokenAsync (TokenRequestContext requestContext, CancellationToken cancellationToken)
-        {
-            var token = await new AzureServiceTokenProvider ().GetAccessTokenAsync ("https://vault.azure.net", string.Empty);
-            return new AccessToken (token, DateTimeOffset.UtcNow.AddMinutes (5.0));
-        }
-
-        public override AccessToken GetToken (TokenRequestContext requestContext, CancellationToken cancellationToken)
-        {
-            return GetTokenAsync (requestContext, cancellationToken).Result;
-        }
-    }
-
     public class KeyVaultModule: Module
     {
         protected override void Load(ContainerBuilder builder)
@@ -42,7 +29,7 @@ namespace CaptainHook.Common.Configuration.KeyVault
 
             builder.Register(context => new SecretClient(
                 new Uri(Environment.GetEnvironmentVariable(ConfigurationSettings.KeyVaultUriEnvVariable)),
-                new AzureServiceTokenCredential(),
+                new DefaultAzureCredential(),
                 secretClientOptions));
             builder.RegisterType<KeyVaultSecretProvider>().As<ISecretProvider>();
         }

--- a/src/CaptainHook.Common/Configuration/TempConfigLoader.cs
+++ b/src/CaptainHook.Common/Configuration/TempConfigLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using CaptainHook.Common.Configuration.KeyVault;
 using Eshopworld.DevOps;
@@ -48,7 +49,7 @@ namespace CaptainHook.Common.Configuration
         {
             return new SecretClient (
                 new Uri (Environment.GetEnvironmentVariable (ConfigurationSettings.KeyVaultUriEnvVariable)),
-                new AzureServiceTokenCredential (),
+                new DefaultAzureCredential(),
                 new SecretClientOptions ());
         }
 


### PR DESCRIPTION
### What
With the new Azure SDK, let's switch to DefaultAzureCredential for Azure authentication instead of the custom AzureServiceTokenCredential implementation.

### Why
The DefaultAzureCredential class provides a default TokenCredential authentication flow for applications that will be deployed to Azure. The following credential types if enabled will be tried, in order:
- EnvironmentCredential
- ManagedIdentityCredential
- SharedTokenCacheCredential
- InteractiveBrowserCredential

### Reference
- https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet
- https://www.rahulpnath.com/blog/defaultazurecredential_from_azure_sdk/

### Notes
In your local environment, DefaultAzureCredential uses the shared token credential from the IDE. In the case of Visual Studio, please make sure the account to use is properly configured under Options -> Azure Service Authentication.