### PR TITLE
#76794 - remove unused url validation preventing uri replacement

### DIFF
--- a/src/CaptainHook.Common/Configuration/ConfigParser.cs
+++ b/src/CaptainHook.Common/Configuration/ConfigParser.cs
@@ -1,7 +1,6 @@
 ﻿using CaptainHook.Common.Authentication;
 using Microsoft.Extensions.Configuration;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace CaptainHook.Common.Configuration
@@ -14,14 +13,11 @@ namespace CaptainHook.Common.Configuration
         /// <summary>
         /// Creates a list of unique endpoints which are used for authentication sharing and pooling
         /// </summary>
-        /// <param name="webhookConfig"></param>
-        /// <param name="endpointList"></param>
         /// <param name="configurationSection"></param>
         /// <param name="path"></param>
-        public static void AddEndpoints(WebhookConfig webhookConfig, IDictionary<string, WebhookConfig> endpointList, IConfiguration configurationSection, string path)
+        public static void AddEndpoints(WebhookConfig webhookConfig, IConfiguration configurationSection, string path)
         {
             if (webhookConfig == null) throw new ArgumentNullException(nameof(webhookConfig));
-            if (endpointList == null) throw new ArgumentNullException(nameof(endpointList));
             if (configurationSection == null) throw new ArgumentNullException(nameof(configurationSection));
 
             //creates a list of endpoints so they can be shared for authentication and http pooling
@@ -45,13 +41,8 @@ namespace CaptainHook.Common.Configuration
 
                         var authPath = $"{path}:webhookrequestrules:{i + 1}:routes:{y + 1}:authenticationconfig";
                         ParseAuthScheme(route, configurationSection, authPath);
-                        AddToDictionarySafely(endpointList, route);
                     }
                 }
-            }
-            else
-            {
-                AddToDictionarySafely(endpointList, webhookConfig);
             }
         }
 
@@ -85,20 +76,6 @@ namespace CaptainHook.Common.Configuration
 
             route.AuthenticationConfig = ParseOidcAuthenticationConfig(configurationSection.GetSection(path));
             route.AuthenticationConfig.Type = AuthenticationType.Custom;
-        }
-
-        /// <summary>
-        /// Safe adds to the dictionary if it does not already exist
-        /// </summary>
-        /// <param name="endpointList"></param>
-        /// <param name="rule"></param>
-        public static void AddToDictionarySafely(IDictionary<string, WebhookConfig> endpointList, WebhookConfig rule)
-        {
-            var uri = new Uri(rule.Uri);
-            if (!endpointList.ContainsKey(uri.Host.ToLowerInvariant()))
-            {
-                endpointList.Add(uri.Host.ToLowerInvariant(), rule);
-            }
         }
 
         /// <summary>

--- a/src/CaptainHook.Common/Configuration/Configuration.cs
+++ b/src/CaptainHook.Common/Configuration/Configuration.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 
 namespace CaptainHook.Common.Configuration
@@ -50,7 +48,6 @@ namespace CaptainHook.Common.Configuration
 
             this.SubscriberConfigurations = new Dictionary<string, SubscriberConfiguration>(values.Count);
             this.WebhookConfigurations = new List<WebhookConfig>(values.Count);
-            var endpointList = new Dictionary<string, WebhookConfig>(values.Count);
 
             foreach (var configurationSection in values)
             {
@@ -69,7 +66,7 @@ namespace CaptainHook.Common.Configuration
                     subscriber.PayloadTransformation = subscriber.DLQMode != null ? PayloadContractTypeEnum.WrapperContract : PayloadContractTypeEnum.Raw;
 
                     this.WebhookConfigurations.Add(subscriber);
-                    ConfigParser.AddEndpoints(subscriber, endpointList, configurationSection, path);
+                    ConfigParser.AddEndpoints(subscriber, configurationSection, path);
 
                     if (subscriber.Callback != null)
                     {
@@ -77,7 +74,7 @@ namespace CaptainHook.Common.Configuration
                         ConfigParser.ParseAuthScheme(subscriber.Callback, configurationSection, $"{path}:authenticationconfig");
                         subscriber.Callback.EventType = eventHandlerConfig.Type;
                         this.WebhookConfigurations.Add(subscriber.Callback);
-                        ConfigParser.AddEndpoints(subscriber.Callback, endpointList, configurationSection, path);
+                        ConfigParser.AddEndpoints(subscriber.Callback, configurationSection, path);
                     }
                 }
             }

--- a/src/Tests/CaptainHook.Tests/Configuration/KeyVaultProviderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Configuration/KeyVaultProviderTests.cs
@@ -32,7 +32,7 @@ namespace CaptainHook.Tests.Configuration
 
             var eventHandlerList = new List<EventHandlerConfig>();
             var webhookList = new List<WebhookConfig>(values.Count);
-            var endpointList = new Dictionary<string, WebhookConfig>(values.Count);
+            
             foreach (var configurationSection in values)
             {
                 //temp work around until config comes in through the API
@@ -44,21 +44,20 @@ namespace CaptainHook.Tests.Configuration
                     var path = "webhookconfig";
                     ConfigParser.ParseAuthScheme(subscriber, configurationSection, $"{path}:authenticationconfig");
                     webhookList.Add(subscriber);
-                    ConfigParser.AddEndpoints(subscriber, endpointList, configurationSection, path);
+                    ConfigParser.AddEndpoints(subscriber, configurationSection, path);
 
                     if (subscriber.Callback != null)
                     {
                         path = "callbackconfig";
                         ConfigParser.ParseAuthScheme(subscriber.Callback, configurationSection, $"{path}:authenticationconfig");
                         webhookList.Add(subscriber.Callback);
-                        ConfigParser.AddEndpoints(subscriber.Callback, endpointList, configurationSection, path);
+                        ConfigParser.AddEndpoints(subscriber.Callback, configurationSection, path);
                     }
                 }
             }
 
             Assert.NotEmpty(eventHandlerList);
             Assert.NotEmpty(webhookList);
-            Assert.NotEmpty(endpointList);
         }
     }
 }


### PR DESCRIPTION
### What
Removal of URI validation which was intended to reuse hosts, but actually was never used. Through that mechanism, a placeholder in the host was unaccepted causing an exception. This is not something that config loader should occupy itself with. The endpointlist collection was not used anyway so I have decided to remove it.