### PR TITLE
#76794 - remove placeholders for http client caching

### DIFF
--- a/src/CaptainHook.EventHandlerActor/Handlers/HttpClientFactory.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/HttpClientFactory.cs
@@ -38,7 +38,8 @@ namespace CaptainHook.EventHandlerActor.Handlers
         {
             if (config == null) throw new ArgumentNullException(nameof(config));
 
-            var uri = new Uri(config.Uri);
+            var uriString = config.Uri?.Replace("{", string.Empty).Replace("}", string.Empty);
+            var uri = new Uri(uriString);
 
             if (_httpClients.TryGetValue(uri.Host.ToLowerInvariant(), out var httpClient))
             {

--- a/src/CaptainHook.EventHandlerActor/Handlers/Requests/BuildUriContext.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Requests/BuildUriContext.cs
@@ -7,8 +7,9 @@ namespace CaptainHook.EventHandlerActor.Handlers.Requests
     public class BuildUriContext
     {
         private readonly string _originalUri;
-        private readonly string _selector;
+        
         private readonly Action<string> _publishUnroutableEvent;
+
         private string _replacedUri;
 
         public BuildUriContext([NotNull] string uri, Action<string> publishUnroutableEvent)


### PR DESCRIPTION
### What
Placeholder in the host broke the algorithm. Its presence in other parts is accepted, however. This is a blunt fix as I wasn't able to achieve a design I originally wanted without changing the implementation extensively.