### PR TITLE
#77383 - include http verb for route and replace

### DIFF
--- a/src/CaptainHook.EventHandlerActor/Handlers/Requests/DefaultRequestBuilder.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Requests/DefaultRequestBuilder.cs
@@ -179,7 +179,7 @@ namespace CaptainHook.EventHandlerActor.Handlers.Requests
 
         /// <inheritdoc />
 
-        public HttpMethod SelectHttpMethod(WebhookConfig webhookConfig, string payload)
+        public virtual HttpMethod SelectHttpMethod(WebhookConfig webhookConfig, string payload)
         {
             if (webhookConfig == null) throw new ArgumentNullException(nameof(webhookConfig));
 
@@ -207,7 +207,7 @@ namespace CaptainHook.EventHandlerActor.Handlers.Requests
         }
 
         /// <inheritdoc />
-        public WebhookConfig GetAuthenticationConfig(WebhookConfig webhookConfig, string payload)
+        public virtual WebhookConfig GetAuthenticationConfig(WebhookConfig webhookConfig, string payload)
         {
             if (webhookConfig == null) throw new ArgumentNullException(nameof(webhookConfig));
 

--- a/src/CaptainHook.EventHandlerActor/Handlers/Requests/RouteAndReplaceRequestBuilder.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Requests/RouteAndReplaceRequestBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using CaptainHook.Common;
 using CaptainHook.Common.Configuration;
 using Eshopworld.Core;
@@ -54,6 +55,11 @@ namespace CaptainHook.EventHandlerActor.Handlers.Requests
 
             return routeConfig;
         }
+
+        public override HttpMethod SelectHttpMethod(WebhookConfig webhookConfig, string payload) =>
+            SelectWebhookConfig(webhookConfig, payload).HttpMethod;
+
+        public override WebhookConfig GetAuthenticationConfig(WebhookConfig webhookConfig, string payload) => SelectWebhookConfig(webhookConfig, payload);
 
         private IDictionary<string, string> BuildReplacementDictionary(
             IDictionary<string, string> sourceReplace,

--- a/src/Tests/CaptainHook.Tests/Services/Actors/Requests/RouteAndReplaceRequestBuilderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Actors/Requests/RouteAndReplaceRequestBuilderTests.cs
@@ -148,6 +148,27 @@ namespace CaptainHook.Tests.Services.Actors.Requests
             actualConfig.Should().BeEquivalentTo(expectedWebhookConfig);
         }
 
+        [IsUnit]
+        [Theory]
+        [MemberData(nameof(WebhookConfigData))]
+        public void GetAuthenticationConfigTests(WebhookConfig config, string payload, WebhookConfig expectedWebhookConfig)
+        {
+            var actualConfig = _builder.GetAuthenticationConfig(config, payload);
+
+            actualConfig.Should().BeEquivalentTo(expectedWebhookConfig);
+        }
+
+
+        [IsUnit]
+        [Theory]
+        [MemberData(nameof(WebhookConfigData))]
+        public void SelectHttpMethodTests(WebhookConfig config, string payload, WebhookConfig expectedWebhookConfig)
+        {
+            var actualHttpMethod = _builder.SelectHttpMethod(config, payload);
+
+            actualHttpMethod.Should().Be(expectedWebhookConfig.HttpMethod);
+        }
+
         public static IEnumerable<object[]> UriDataRouteAndReplace =>
             new List<object[]>
             {
@@ -218,16 +239,19 @@ namespace CaptainHook.Tests.Services.Actors.Requests
                             .WithDestination(ruleAction: RuleAction.RouteAndReplace)
                             .AddRoute(route => route
                                 .WithUri("https://blah.blah.Brand1.eshopworld.com/webhook/{orderCode}")
+                                .WithHttpVerb("PUT")
                                 .WithSelector("Brand1")
                                 .WithNoAuthentication())
                             .AddRoute(route => route
                                 .WithUri("https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}")
+                                .WithHttpVerb("GET")
                                 .WithSelector("*")
                                 .WithNoAuthentication()))
                         .Create(),
                     "{\"OrderCode\":\"9744b831-df2c-4d59-9d9d-691f4121f73a\", \"BrandType\":\"Brand2\", \"TenantCode\":\"tenant1\"}",
                     new WebhookConfigRouteBuilder()
                         .WithUri("https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}")
+                        .WithHttpVerb("GET")
                         .WithSelector("*")
                         .WithNoAuthentication()
                         .Create()
@@ -242,16 +266,19 @@ namespace CaptainHook.Tests.Services.Actors.Requests
                             .WithDestination(ruleAction: RuleAction.RouteAndReplace)
                             .AddRoute(route => route
                                 .WithUri("https://blah.blah.Brand1.eshopworld.com/webhook/{orderCode}")
+                                .WithHttpVerb("GET")
                                 .WithSelector("tenant0")
                                 .WithNoAuthentication())
                             .AddRoute(route => route
                                 .WithUri("https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}")
+                                .WithHttpVerb("PUT")
                                 .WithSelector("*")
                                 .WithNoAuthentication()))
                         .Create(),
                     "{\"OrderCode\":\"9744b831-df2c-4d59-9d9d-691f4121f73a\", \"BrandType\":\"Brand2\", \"TenantCode\":\"tenant0\"}",
                     new WebhookConfigRouteBuilder()
                         .WithUri("https://blah.blah.Brand1.eshopworld.com/webhook/{orderCode}")
+                        .WithHttpVerb("GET")
                         .WithSelector("tenant0")
                         .WithNoAuthentication()
                         .Create()
@@ -266,12 +293,14 @@ namespace CaptainHook.Tests.Services.Actors.Requests
                             .WithDestination(ruleAction: RuleAction.RouteAndReplace)
                             .AddRoute(route => route
                                 .WithUri("https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}")
+                                .WithHttpVerb("PUT")
                                 .WithSelector("*")
                                 .WithNoAuthentication()))
                         .Create(),
                     "{\"OrderCode\":\"9744b831-df2c-4d59-9d9d-691f4121f73a\", \"BrandType\":\"Brand2\", \"TenantCode\":\"tenant1\"}",
                     new WebhookConfigRouteBuilder()
                         .WithUri("https://blah.blah.{selector}.eshopworld.com/webhook/{orderCode}")
+                        .WithHttpVerb("PUT")
                         .WithSelector("*")
                         .WithNoAuthentication()
                         .Create()


### PR DESCRIPTION
### What
Route and Replace incorrectly used HTTP verb for its requests. The current PR changes that by using the HTTP verb defined for the particular endpoint.