### PR TITLE
Task 77087 persist scope uri transform in cosmos

### DIFF
--- a/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
@@ -65,7 +65,7 @@ namespace CaptainHook.Application.Handlers.Subscribers
             var secretStoreEntity = new SecretStoreEntity(authDto.ClientSecret.Vault, authDto.ClientSecret.Name);
             var authenticationEntity = new AuthenticationEntity(authDto.ClientId, secretStoreEntity, authDto.Uri, authDto.Type, authDto.Scopes.ToArray());
             var uriTransformEntity = request.Endpoint?.UriTransform != null ? new UriTransformEntity(request.Endpoint.UriTransform.Replace) : null;
-            var endpoint = new EndpointEntity(request.Endpoint.Uri, authenticationEntity, request.Endpoint.HttpVerb, uriTransformEntity);
+            var endpoint = new EndpointEntity(request.Endpoint.Uri, authenticationEntity, request.Endpoint.HttpVerb, null, subscriber, uriTransformEntity);
             subscriber.AddWebhookEndpoint(endpoint);
             return subscriber;
         }

--- a/src/CaptainHook.Domain/Entities/EndpointEntity.cs
+++ b/src/CaptainHook.Domain/Entities/EndpointEntity.cs
@@ -32,24 +32,16 @@
 
         public UriTransformEntity UriTransform { get; }
 
-        public EndpointEntity(string uri, AuthenticationEntity authentication, string httpVerb, string selector) : this(uri, authentication, httpVerb, selector, null) { }
-
-        public EndpointEntity(string uri, AuthenticationEntity authentication, string httpVerb, string selector, SubscriberEntity subscriber)
+        public EndpointEntity(string uri, AuthenticationEntity authentication, string httpVerb, string selector, 
+            SubscriberEntity subscriber = null, UriTransformEntity uriTransform = null)
         {
             Uri = uri;
             Authentication = authentication;
             HttpVerb = httpVerb;
             Selector = selector;
+            UriTransform = uriTransform;
 
             SetParentSubscriber(subscriber);
-        }
-
-        public EndpointEntity(string uri, AuthenticationEntity authentication, string httpVerb, UriTransformEntity uriTransform)
-        {
-            Uri = uri;
-            Authentication = authentication;
-            HttpVerb = httpVerb;
-            UriTransform = uriTransform;
         }
 
         public void SetParentSubscriber(SubscriberEntity subscriber)

--- a/src/CaptainHook.Storage.Cosmos/Models/EndpointSubdocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/EndpointSubdocument.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace CaptainHook.Storage.Cosmos.Models
 {
@@ -16,8 +17,8 @@ namespace CaptainHook.Storage.Cosmos.Models
         /// <summary>
         /// Endpoint selector
         /// </summary>
-        [JsonProperty("endpointSelector")]
-        public string EndpointSelector { get; set; }
+        [JsonProperty("selector", NullValueHandling = NullValueHandling.Ignore)]
+        public string Selector { get; set; }
 
         /// <summary>
         /// Endpoint authentication
@@ -30,5 +31,18 @@ namespace CaptainHook.Storage.Cosmos.Models
         /// </summary>
         [JsonProperty("httpVerb")]
         public string HttpVerb { get; set; }
+
+        /// <summary>
+        /// Endpoint type (Webhook, Subscriber, DLQ)
+        /// </summary>
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EndpointType Type { get; set; }
+
+        /// <summary>
+        /// Defines Uri transformation definition
+        /// </summary>
+        [JsonProperty("uriTransform", NullValueHandling = NullValueHandling.Ignore)]
+        public UriTransformDocument UriTransform { get; set; }
     }
 }

--- a/src/CaptainHook.Storage.Cosmos/Models/EndpointType.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/EndpointType.cs
@@ -1,0 +1,11 @@
+﻿namespace CaptainHook.Storage.Cosmos.Models
+{
+    internal enum EndpointType
+    {
+        Webhook = 0,
+        
+        Callback,
+        
+        Dlq
+    }
+}

--- a/src/CaptainHook.Storage.Cosmos/Models/SubscriberDocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/SubscriberDocument.cs
@@ -37,12 +37,6 @@ namespace CaptainHook.Storage.Cosmos.Models
         public string SubscriberName { get; set; }
 
         /// <summary>
-        /// Webhook type (Webhook, Subscriber, DLQ)
-        /// </summary>
-        [JsonProperty("webhookType")]
-        public WebhookType WebhookType { get; set; }
-
-        /// <summary>
         /// Event name
         /// </summary>
         [JsonProperty("eventName")]

--- a/src/CaptainHook.Storage.Cosmos/Models/UriTransformDocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/UriTransformDocument.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Newtonsoft.Json;
+
+namespace CaptainHook.Storage.Cosmos.Models
+{
+    public class UriTransformDocument
+    {
+        public UriTransformDocument(IDictionary<string, string> replace)
+        {
+            Replace = new ReadOnlyDictionary<string, string>(replace ?? new Dictionary<string, string>());
+        }
+
+        [JsonProperty("replace")]
+        public IDictionary<string, string> Replace { get; }
+    }
+}

--- a/src/CaptainHook.Storage.Cosmos/Models/WebhookType.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/WebhookType.cs
@@ -1,7 +1,0 @@
-﻿namespace CaptainHook.Storage.Cosmos.Models
-{
-    internal enum WebhookType
-    {
-        Webhook = 0, Callback, Dlq
-    }
-}

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -63,7 +63,7 @@ namespace CaptainHook.Storage.Cosmos
             var subscribers = await _cosmosDbRepository.QueryAsync<SubscriberDocument>(query);
 
             return subscribers
-                .Select(x => Map(x))
+                .Select(Map)
                 .ToList();
         }
 
@@ -175,16 +175,27 @@ namespace CaptainHook.Storage.Cosmos
 
             foreach (var endpointDocument in subscriberDocument.Endpoints)
             {
-                subscriberEntity.AddWebhookEndpoint(Map(endpointDocument));
+                subscriberEntity.AddWebhookEndpoint(Map(endpointDocument, subscriberEntity));
             }
 
             return subscriberEntity;
         }
 
-        private EndpointEntity Map(EndpointSubdocument endpoint)
+        private EndpointEntity Map(EndpointSubdocument endpoint, SubscriberEntity subscriberEntity)
         {
             var authentication = Map(endpoint.Authentication);
-            return new EndpointEntity(endpoint.Uri, authentication, endpoint.HttpVerb, endpoint.Selector);
+            var uriTransform = Map(endpoint.UriTransform);
+            return new EndpointEntity(endpoint.Uri, authentication, endpoint.HttpVerb, endpoint.Selector, subscriberEntity, uriTransform);
+        }
+
+        private UriTransformEntity Map(UriTransformDocument uriTransform)
+        {
+            if (uriTransform?.Replace == null)
+            {
+                return null;
+            }
+
+            return new UriTransformEntity(uriTransform.Replace);
         }
 
         private AuthenticationEntity Map(AuthenticationData authentication)

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/UpsertWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/UpsertWebhookRequestHandlerTests.cs
@@ -59,8 +59,8 @@ namespace CaptainHook.Application.Tests.Handlers
             var subscriberEntity = new SubscriberBuilder()
                 .WithEvent("event")
                 .WithName("subscriber")
-                .WithWebhook("https://blah.blah.eshopworld.com/oldwebhook/", "POST", "selector",
-                    new AuthenticationEntity(
+                .WithWebhook("https://blah.blah.eshopworld.com/oldwebhook/", "POST", "selector", 
+                    authentication: new AuthenticationEntity(
                         "captain-hook-id",
                         new SecretStoreEntity("kvname", "kv-secret-name"),
                         "https://blah-blah.sts.eshopworld.com",

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests.cs
@@ -30,7 +30,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
             var authentication = new AuthenticationEntity("captain-hook-id", new SecretStoreEntity("kvname", "kv-secret-name"),
                 "https://blah-blah.sts.eshopworld.com", "OIDC", new[] { "scope1" });
             var subscriber = new SubscriberBuilder()
-                .WithWebhook("https://blah-blah.eshopworld.com/webhook/", "POST", string.Empty, authentication)
+                .WithWebhook("https://blah-blah.eshopworld.com/webhook/", "POST", string.Empty, authentication: authentication)
                 .Create();
 
             var result = await new SubscriberEntityToConfigurationMapper(_secretProviderMock.Object).MapSubscriber(subscriber);
@@ -51,7 +51,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
             var uriTransform = new UriTransformEntity(
                 new Dictionary<string, string> { ["selector"] = "$.TenantCode", ["orderCode"] = "$.OrderCode" });
             var subscriber = new SubscriberBuilder()
-                .WithWebhook("https://blah-{selector}.eshopworld.com/webhook/", "POST", uriTransform, authentication)
+                .WithWebhook("https://blah-{selector}.eshopworld.com/webhook/", "POST", null, uriTransform, authentication)
                 .Create();
 
             var result = await new SubscriberEntityToConfigurationMapper(_secretProviderMock.Object).MapSubscriber(subscriber);

--- a/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
+++ b/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
@@ -65,7 +65,8 @@ namespace CaptainHook.Storage.Cosmos.Tests
             {
                 HttpVerb = "POST",
                 Uri = "http://test",
-                EndpointSelector = "selector",
+                Selector = "selector",
+                Type = EndpointType.Webhook,
                 Authentication = new AuthenticationData
                 {
                     ClientId = "clientid",
@@ -80,9 +81,8 @@ namespace CaptainHook.Storage.Cosmos.Tests
             {
                 SubscriberName = "subscriberName",
                 EventName = eventName,
-                WebhookType = WebhookType.Webhook,
                 WebhookSelectionRule = "rule",
-                Endpoints = new EndpointSubdocument[] { endpoint }
+                Endpoints = new[] { endpoint }
             };
             _cosmosDbRepositoryMock
                 .Setup(x => x.QueryAsync<SubscriberDocument>(It.IsAny<CosmosQuery>()))
@@ -91,7 +91,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
             var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
             var sampleAuthStoreEntity = new SecretStoreEntity(endpoint.Authentication.KeyVaultName, endpoint.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(endpoint.Authentication.ClientId, sampleAuthStoreEntity, endpoint.Authentication.Uri, endpoint.Authentication.Type, endpoint.Authentication.Scopes);
-            var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.EndpointSelector);
+            var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.Selector);
             expectedSubscriberEntity.AddWebhookEndpoint(expectedEndpointEntity);
 
             // Act
@@ -112,15 +112,15 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 {
                     SubscriberName = "subscriberName",
                     EventName = eventName,
-                    WebhookType = WebhookType.Webhook,
                     WebhookSelectionRule = "rule",
-                    Endpoints = new EndpointSubdocument[]
+                    Endpoints = new[]
                     {
                         new EndpointSubdocument
                         {
                             HttpVerb = "POST",
                             Uri = "http://test",
-                            EndpointSelector = "selector",
+                            Selector = "selector",
+                            Type = EndpointType.Webhook,
                             Authentication = new AuthenticationData
                             {
                                 ClientId = "clientid",
@@ -135,7 +135,8 @@ namespace CaptainHook.Storage.Cosmos.Tests
                         {
                             HttpVerb = "GET",
                             Uri = "http://test2",
-                            EndpointSelector = "selector2",
+                            Selector = "selector2",
+                            Type = EndpointType.Webhook,
                             Authentication = new AuthenticationData
                             {
                                 ClientId = "clientid",
@@ -231,7 +232,8 @@ namespace CaptainHook.Storage.Cosmos.Tests
             {
                 HttpVerb = "POST",
                 Uri = "http://test",
-                EndpointSelector = "selector",
+                Selector = "selector",
+                Type = EndpointType.Webhook,
                 Authentication = new AuthenticationData
                 {
                     ClientId = "clientid",
@@ -246,9 +248,8 @@ namespace CaptainHook.Storage.Cosmos.Tests
             {
                 SubscriberName = "subscriberName",
                 EventName = eventName,
-                WebhookType = WebhookType.Webhook,
                 WebhookSelectionRule = "rule",
-                Endpoints = new EndpointSubdocument[] { endpoint }
+                Endpoints = new[] { endpoint }
             };
             _cosmosDbRepositoryMock
                 .Setup(x => x.QueryAsync<SubscriberDocument>(It.IsAny<CosmosQuery>()))
@@ -257,7 +258,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
             var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
             var sampleAuthStoreEntity = new SecretStoreEntity(endpoint.Authentication.KeyVaultName, endpoint.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(endpoint.Authentication.ClientId, sampleAuthStoreEntity, endpoint.Authentication.Uri, endpoint.Authentication.Type, endpoint.Authentication.Scopes);
-            var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.EndpointSelector);
+            var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.Selector);
             expectedSubscriberEntity.AddWebhookEndpoint(expectedEndpointEntity);
 
             // Act
@@ -278,15 +279,15 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 {
                     SubscriberName = "subscriberName",
                     EventName = eventName,
-                    WebhookType = WebhookType.Webhook,
                     WebhookSelectionRule = "rule",
-                    Endpoints = new EndpointSubdocument[]
+                    Endpoints = new[]
                     {
                         new EndpointSubdocument
                         {
                             HttpVerb = "POST",
                             Uri = "http://test",
-                            EndpointSelector = "selector",
+                            Selector = "selector",
+                            Type = EndpointType.Webhook,
                             Authentication = new AuthenticationData
                             {
                                 ClientId = "clientid",
@@ -301,7 +302,8 @@ namespace CaptainHook.Storage.Cosmos.Tests
                         {
                             HttpVerb = "GET",
                             Uri = "http://test2",
-                            EndpointSelector = "selector2",
+                            Selector = "selector2",
+                            Type = EndpointType.Webhook,
                             Authentication = new AuthenticationData
                             {
                                 ClientId = "clientid",
@@ -367,7 +369,6 @@ namespace CaptainHook.Storage.Cosmos.Tests
             {
                 SubscriberName = "subscriberName",
                 EventName = "eventName",
-                WebhookType = WebhookType.Webhook,
                 WebhookSelectionRule = "rule",
                 Endpoints = new EndpointSubdocument[] { }
             };
@@ -415,7 +416,6 @@ namespace CaptainHook.Storage.Cosmos.Tests
             {
                 SubscriberName = "subscriberName",
                 EventName = "eventName",
-                WebhookType = WebhookType.Webhook,
                 WebhookSelectionRule = "rule",
                 Endpoints = new EndpointSubdocument[] { }
             };

--- a/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
@@ -108,7 +108,7 @@ namespace CaptainHook.Tests.Director
                         "https://cosmos.eshopworld.com/testevent/",
                         "POST",
                         "selector",
-                        new AuthenticationEntity(
+                        authentication: new AuthenticationEntity(
                             "captain-hook-id",
                             new SecretStoreEntity("kvname", "kv-secret-name"),
                             "https://blah-blah.sts.eshopworld.com",

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberBuilder.cs
@@ -23,30 +23,23 @@ namespace CaptainHook.TestsInfrastructure.Builders
             return this;
         }
 
-        public SubscriberBuilder WithWebhook(string uri, string httpVerb, string selector, AuthenticationEntity authentication = null)
+        public SubscriberBuilder WithWebhook(string uri, string httpVerb, string selector, UriTransformEntity uriTransform = null, AuthenticationEntity authentication = null)
         {
-            var endpoint = new EndpointEntity(uri, authentication, httpVerb, selector);
+            var endpoint = new EndpointEntity(uri, authentication, httpVerb, selector, null, uriTransform);
             _webhooks.Add(endpoint);
             return this;
         }
 
-        public SubscriberBuilder WithWebhook(string uri, string httpVerb, UriTransformEntity uriTransformEntity, AuthenticationEntity authentication = null)
+        public SubscriberBuilder WithCallback(string uri, string httpVerb, string selector, UriTransformEntity uriTransform = null, AuthenticationEntity authentication = null)
         {
-            var endpoint = new EndpointEntity(uri, authentication, httpVerb, uriTransformEntity);
-            _webhooks.Add(endpoint);
-            return this;
-        }
-
-        public SubscriberBuilder WithCallback(string uri, string httpVerb, string selector, AuthenticationEntity authentication = null)
-        {
-            var endpoint = new EndpointEntity(uri, authentication, httpVerb, selector);
+            var endpoint = new EndpointEntity(uri, authentication, httpVerb, selector, null, uriTransform);
             _callbacks.Add(endpoint);
             return this;
         }
 
-        public SubscriberBuilder WithDlq(string uri, string httpVerb, string selector, AuthenticationEntity authentication = null)
+        public SubscriberBuilder WithDlq(string uri, string httpVerb, string selector, UriTransformEntity uriTransform = null, AuthenticationEntity authentication = null)
         {
-            var endpoint = new EndpointEntity(uri, authentication, httpVerb, selector);
+            var endpoint = new EndpointEntity(uri, authentication, httpVerb, selector, null, uriTransform);
             _dlq.Add(endpoint);
             return this;
         }


### PR DESCRIPTION
This is a quick PR to address the cosmos side of things. With these changes API put endpoint request is going to be stored to cosmos. The mapping however need to be worked out.