### PR TITLE
Usages of MessageData.WebhookConfig removed from Actor

### DIFF
--- a/src/CaptainHook.EventHandlerActor/Handlers/EventHandlerFactory.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/EventHandlerFactory.cs
@@ -55,16 +55,16 @@ namespace CaptainHook.EventHandlerActor.Handlers
                     messageData.SubscriberConfig);
             }
 
-            return CreateWebhookHandler(messageData.WebhookConfig, messageData.SubscriberConfig.Name);
+            return CreateWebhookHandler(messageData.SubscriberConfig);
         }
 
         /// <summary>
         /// Creates a single fire and forget webhook handler
         /// Need this here for now to select the handler for the callback
         /// </summary>
-        /// <param name="webHookName"></param>
+        /// <param name="webhookConfig">Webhook configuration</param>
         /// <returns></returns>
-        public IHandler CreateWebhookHandler(WebhookConfig webhookConfig, string webHookName = "")
+        public IHandler CreateWebhookHandler(WebhookConfig webhookConfig)
         {
             if (webhookConfig == null)
             {

--- a/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
@@ -68,8 +68,8 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 }
                 var httpMethod = RequestBuilder.SelectHttpMethod(WebhookConfig, messageData.Payload);
                 var originalPayload = RequestBuilder.BuildPayload(WebhookConfig, messageData.Payload, metadata);
-                var payload = WebhookConfig.PayloadTransformation == PayloadContractTypeEnum.WrapperContract 
-                    ? WrapPayload(originalPayload, WebhookConfig, messageData) 
+                var payload = WebhookConfig.PayloadTransformation == PayloadContractTypeEnum.WrapperContract
+                    ? WrapPayload(originalPayload, WebhookConfig, messageData)
                     : originalPayload;
 
                 var config = RequestBuilder.SelectWebhookConfig(WebhookConfig, messageData.Payload);
@@ -77,9 +77,9 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 var authenticationConfig = RequestBuilder.GetAuthenticationConfig(WebhookConfig, messageData.Payload);
 
                 var httpClient = HttpClientFactory.Get(config);
-                
+
                 await AddAuthenticationHeaderAsync(cancellationToken, authenticationConfig, headers);
-                
+
                 var response = await httpClient.SendRequestReliablyAsync(httpMethod, uri, headers, payload, cancellationToken);
 
                 await _requestLogger.LogAsync(httpClient, response, messageData, payload, uri, httpMethod, headers, config);

--- a/src/CaptainHook.EventHandlerActor/Handlers/IEventHandlerFactory.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/IEventHandlerFactory.cs
@@ -19,8 +19,8 @@ namespace CaptainHook.EventHandlerActor.Handlers
         /// <summary>
         /// Used only for getting the callback handler
         /// </summary>
-        /// <param name="webHookName"></param>
+        /// <param name="webhookConfig"></param>
         /// <returns></returns>
-        IHandler CreateWebhookHandler(WebhookConfig webhookConfig, string webHookName= "");
+        IHandler CreateWebhookHandler(WebhookConfig webhookConfig);
     }
 }


### PR DESCRIPTION
This change must be deployed first to support backward compatibility.