### PR TITLE
#78982 - add handler for subscriber request

### DIFF
--- a/src/CaptainHook.Application/Handlers/Subscribers/UpsertSubscriberRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/UpsertSubscriberRequestHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Application.Infrastructure.DirectorService;
@@ -13,18 +14,18 @@ using MediatR;
 
 namespace CaptainHook.Application.Handlers.Subscribers
 {
-    public class UpsertWebhookRequestHandler : IRequestHandler<UpsertWebhookRequest, OperationResult<EndpointDto>>
+    public class UpsertSubscriberRequestHandler: IRequestHandler<UpsertSubscriberRequest, OperationResult<SubscriberDto>>
     {
         private readonly ISubscriberRepository _subscriberRepository;
         private readonly IDirectorServiceProxy _directorService;
 
-        public UpsertWebhookRequestHandler(ISubscriberRepository subscriberRepository, IDirectorServiceProxy directorService)
+        public UpsertSubscriberRequestHandler(ISubscriberRepository subscriberRepository, IDirectorServiceProxy directorService)
         {
             _subscriberRepository = subscriberRepository;
             _directorService = directorService;
         }
 
-        public async Task<OperationResult<EndpointDto>> Handle(UpsertWebhookRequest request, CancellationToken cancellationToken)
+        public async Task<OperationResult<SubscriberDto>> Handle(UpsertSubscriberRequest request, CancellationToken cancellationToken)
         {
             try
             {
@@ -50,24 +51,36 @@ namespace CaptainHook.Application.Handlers.Subscribers
                     return saveResult.Error;
                 }
 
-                return request.Endpoint;
+                return request.Subscriber;
             }
             catch (Exception ex)
             {
-                return new UnhandledExceptionError($"Error processing {nameof(UpsertWebhookRequest)}", ex);
+                return new UnhandledExceptionError($"Error processing {nameof(UpsertSubscriberRequest)}", ex);
             }
         }
 
-        private static SubscriberEntity MapRequestToEntity(UpsertWebhookRequest request)
+        private static SubscriberEntity MapRequestToEntity(UpsertSubscriberRequest request)
         {
-            var subscriber = new SubscriberEntity(request.SubscriberName, new EventEntity(request.EventName));
-            var authDto = request.Endpoint.Authentication;
+            var webhooks = new WebhooksEntity(
+                request.Subscriber.Webhooks.SelectionRule,
+                request.Subscriber.Webhooks.Endpoints?.Select(MapEndpointEntity) ?? Enumerable.Empty<EndpointEntity>());
+            var subscriber = new SubscriberEntity(
+                    request.SubscriberName,
+                    new EventEntity(request.EventName))
+                .AddWebhooks(webhooks);
+
+            return subscriber;
+        }
+
+        private static EndpointEntity MapEndpointEntity(EndpointDto endpointDto)
+        {
+            var authDto = endpointDto.Authentication;
             var secretStoreEntity = new SecretStoreEntity(authDto.ClientSecret.Vault, authDto.ClientSecret.Name);
             var authenticationEntity = new AuthenticationEntity(authDto.ClientId, secretStoreEntity, authDto.Uri, authDto.Type, authDto.Scopes.ToArray());
-            var uriTransformEntity = request.Endpoint?.UriTransform != null ? new UriTransformEntity(request.Endpoint.UriTransform.Replace) : null;
-            var endpoint = new EndpointEntity(request.Endpoint.Uri, authenticationEntity, request.Endpoint.HttpVerb, null, subscriber, uriTransformEntity);
-            subscriber.AddWebhookEndpoint(endpoint);
-            return subscriber;
+            var uriTransformEntity = endpointDto.UriTransform != null ? new UriTransformEntity(endpointDto.UriTransform.Replace) : null;
+            var endpoint = new EndpointEntity(endpointDto.Uri, authenticationEntity, endpointDto.HttpVerb, endpointDto.Selector, uriTransform: uriTransformEntity);
+
+            return endpoint;
         }
     }
 }

--- a/src/CaptainHook.Application/Requests/Subscribers/UpsertSubscriberRequest.cs
+++ b/src/CaptainHook.Application/Requests/Subscribers/UpsertSubscriberRequest.cs
@@ -4,7 +4,7 @@ using MediatR;
 
 namespace CaptainHook.Application.Requests.Subscribers
 {
-    public class UpsertSubscriberRequest : IRequest<OperationResult<EndpointDto>>
+    public class UpsertSubscriberRequest : IRequest<OperationResult<SubscriberDto>>
     {
         public string EventName { get; }
         public string SubscriberName { get; }

--- a/src/CaptainHook.Contract/EndpointDto.cs
+++ b/src/CaptainHook.Contract/EndpointDto.cs
@@ -26,5 +26,10 @@ namespace CaptainHook.Contract
         /// URI transformation
         /// </summary>
         public UriTransformDto UriTransform { get; set; }
+
+        /// <summary>
+        /// Selector
+        /// </summary>
+        public string Selector { get; set; }
     }
 }

--- a/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
+++ b/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
@@ -22,15 +22,12 @@ namespace CaptainHook.Domain.Entities
         /// <summary>
         /// Collection of webhook enpoints
         /// </summary>
-        public WebhooksEntity Webhooks { get; }
+        public WebhooksEntity Webhooks { get; private set; }
 
-        public SubscriberEntity(string name) : this(name, null, null) { }
-        public SubscriberEntity(string name, string webhookSelectionRule) : this(name, webhookSelectionRule, null) { }
-        public SubscriberEntity(string name, string webhookSelectionRule, EventEntity parentEvent)
+        public SubscriberEntity(string name) : this(name, null) { }
+        public SubscriberEntity(string name, EventEntity parentEvent)
         {
             Name = name;
-            Webhooks = new WebhooksEntity(webhookSelectionRule);
-
             SetParentEvent(parentEvent);
         }
 
@@ -45,8 +42,25 @@ namespace CaptainHook.Domain.Entities
         /// <param name="endpointModel"></param>
         public SubscriberEntity AddWebhookEndpoint(EndpointEntity endpointModel)
         {
+            if (Webhooks == null)
+            {
+                Webhooks = new WebhooksEntity();
+            }
+
             endpointModel.SetParentSubscriber(this);
             Webhooks.AddEndpoint(endpointModel);
+
+            return this;
+        }
+
+        public SubscriberEntity AddWebhooks(WebhooksEntity webhooks)
+        {
+            foreach (var webhooksEndpoint in webhooks.Endpoints)
+            {
+                webhooksEndpoint.SetParentSubscriber(this);
+            }
+
+            Webhooks = new WebhooksEntity(webhooks.SelectionRule, webhooks.Endpoints);
 
             return this;
         }

--- a/src/CaptainHook.Domain/Entities/WebhooksEntity.cs
+++ b/src/CaptainHook.Domain/Entities/WebhooksEntity.cs
@@ -21,6 +21,11 @@ namespace CaptainHook.Domain.Entities
         /// </summary>
         public IEnumerable<EndpointEntity> Endpoints => _endpoints;
 
+        public WebhooksEntity()
+            : this(null, null)
+        {
+        }
+
         public WebhooksEntity(string selectionRule): this(selectionRule, null) { }
 
         public WebhooksEntity(string selectionRule, IEnumerable<EndpointEntity> endpoints)

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -170,7 +170,6 @@ namespace CaptainHook.Storage.Cosmos
 
             var subscriberEntity = new SubscriberEntity(
                 subscriberDocument.SubscriberName,
-                subscriberDocument.WebhookSelectionRule,
                 eventEntity);
 
             foreach (var endpointDocument in subscriberDocument.Endpoints)

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CaptainHook.Application.Handlers.Subscribers;
+using CaptainHook.Application.Infrastructure.DirectorService;
+using CaptainHook.Application.Requests.Subscribers;
+using CaptainHook.Contract;
+using CaptainHook.Domain.Entities;
+using CaptainHook.Domain.Errors;
+using CaptainHook.Domain.Repositories;
+using CaptainHook.Domain.Results;
+using CaptainHook.Domain.ValueObjects;
+using CaptainHook.TestsInfrastructure.Builders;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace CaptainHook.Application.Tests.Handlers.Subscribers
+{
+    public class UpsertSubscriberRequestHandlerTests
+    {
+        private readonly Mock<ISubscriberRepository> _repositoryMock = new Mock<ISubscriberRepository>(MockBehavior.Strict);
+
+        private readonly Mock<IDirectorServiceProxy> _directorServiceMock = new Mock<IDirectorServiceProxy>(MockBehavior.Strict);
+
+        private readonly UpsertSubscriberRequest _testRequest = new UpsertSubscriberRequest("event", "subscriber", new SubscriberDtoBuilder().Create());
+
+        private readonly UpsertSubscriberRequestHandler _handler;
+
+        public UpsertSubscriberRequestHandlerTests()
+        {
+            _handler = new UpsertSubscriberRequestHandler(_repositoryMock.Object, _directorServiceMock.Object);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_SubscriberDoesNotExist_Then_NewOneWillBePassedToDirectorServiceAndStoredInRepository()
+        {
+            var endpointDto = new EndpointDtoBuilder()
+                .With(x => x.Uri, "https://blah-{selector}.eshopworld.com/webhook/")
+                .With(x => x.UriTransform, new UriTransformDto { Replace = new Dictionary<string, string> { ["selector"] = "$.TenantCode" } })
+                .Create();
+            var subscriberDto = new SubscriberDtoBuilder()
+                .With(s => s.Webhooks,
+                    new WebhooksDto { SelectionRule = "$.TestRule", Endpoints = new List<EndpointDto> { endpointDto } })
+                .Create();
+            var request = new UpsertSubscriberRequest("event", "subscriber", subscriberDto);
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.IsAny<SubscriberId>()))
+                .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
+            _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
+                .ReturnsAsync(true);
+            _repositoryMock.Setup(r => r.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
+                .ReturnsAsync(new SubscriberEntity("subscriber"));
+
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(subscriberDto);
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_Subscriber_DoesExist_Then_OperationFails()
+        {
+            var subscriberEntity = new SubscriberBuilder()
+                .WithEvent("event")
+                .WithName("subscriber")
+                .WithWebhook("https://blah.blah.eshopworld.com/oldwebhook/", "POST", "selector",
+                    authentication: new AuthenticationEntity(
+                        "captain-hook-id",
+                        new SecretStoreEntity("kvname", "kv-secret-name"),
+                        "https://blah-blah.sts.eshopworld.com",
+                        "OIDC",
+                        new[] { "scope1" })
+                ).Create();
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .ReturnsAsync(subscriberEntity);
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new BusinessError("Updating subscribers not supported!"));
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_RepositoryFailsRetrievingSubscriberData_Then_OperationFails()
+        {
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .ReturnsAsync(new BusinessError("test error"));
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new BusinessError("Updating subscribers not supported!"));
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_RepositoryThrowsAnExceptionRetrievingSubscriberData_Then_OperationFails()
+        {
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .Throws<Exception>();
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new UnhandledExceptionError("Error processing UpsertSubscriberRequest", new Exception()));
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_DirectorServiceIsBusyReloading_Then_OperationFails()
+        {
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
+            _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
+                .ReturnsAsync(new DirectorServiceIsBusyError());
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new DirectorServiceIsBusyError());
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_DirectorServiceFailsToCreateReaderAsync_Then_OperationFails()
+        {
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
+            _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
+                .ReturnsAsync(new ReaderCreationError(new SubscriberEntity("subscriber")));
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new ReaderCreationError(new SubscriberEntity("subscriber")));
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_DirectorServiceThrowsAnExceptionDuringReaderCreation_Then_OperationFails()
+        {
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
+            _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
+                 .Throws<Exception>();
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new UnhandledExceptionError("Error processing UpsertSubscriberRequest", new Exception()));
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_RepositoryFailsSavingSubscriberAfterSuccessfulReaderCreation_Then_OperationFails()
+        {
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
+            _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
+                .ReturnsAsync(true);
+            _repositoryMock.Setup(r => r.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
+                .ReturnsAsync(new BusinessError("test error"));
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new BusinessError("test error"));
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact, IsUnit]
+        public async Task When_RepositoryThrowsAnExceptionSavingSubscriberAfterSuccessfulReaderCreation_Then_OperationFails()
+        {
+            _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
+                .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
+            _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>())).ReturnsAsync(false);
+            _repositoryMock.Setup(r => r.AddSubscriberAsync(It.IsAny<SubscriberEntity>())).Throws<Exception>();
+
+            var result = await _handler.Handle(_testRequest, CancellationToken.None);
+
+            var expectedResult = new OperationResult<SubscriberDto>(new UnhandledExceptionError("Error processing UpsertSubscriberRequest", new Exception()));
+            result.Should().BeEquivalentTo(expectedResult);
+        }
+    }
+}

--- a/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
+++ b/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
@@ -88,7 +88,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 .Setup(x => x.QueryAsync<SubscriberDocument>(It.IsAny<CosmosQuery>()))
                 .ReturnsAsync(new List<SubscriberDocument> { sampleDocument });
 
-            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
+            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, new EventEntity(eventName));
             var sampleAuthStoreEntity = new SecretStoreEntity(endpoint.Authentication.KeyVaultName, endpoint.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(endpoint.Authentication.ClientId, sampleAuthStoreEntity, endpoint.Authentication.Uri, endpoint.Authentication.Type, endpoint.Authentication.Scopes);
             var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.Selector);
@@ -161,7 +161,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
             // Assert
             var expected = new[]
             {
-                new SubscriberEntity("subscriberName", "rule", new EventEntity(eventName))
+                new SubscriberEntity("subscriberName", new EventEntity(eventName))
                     .AddWebhookEndpoint(new EndpointEntity(
                         "http://test",
                         new AuthenticationEntity(
@@ -255,7 +255,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 .Setup(x => x.QueryAsync<SubscriberDocument>(It.IsAny<CosmosQuery>()))
                 .ReturnsAsync(new List<SubscriberDocument> { sampleDocument });
 
-            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, sampleDocument.WebhookSelectionRule, new EventEntity(eventName));
+            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, new EventEntity(eventName));
             var sampleAuthStoreEntity = new SecretStoreEntity(endpoint.Authentication.KeyVaultName, endpoint.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(endpoint.Authentication.ClientId, sampleAuthStoreEntity, endpoint.Authentication.Uri, endpoint.Authentication.Type, endpoint.Authentication.Scopes);
             var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.Selector);
@@ -326,7 +326,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
             var result = await _repository.GetSubscriberAsync(new SubscriberId(eventName, "subscriberName"));
 
             // Assert
-            var expected = new SubscriberEntity("subscriberName", "rule", new EventEntity(eventName))
+            var expected = new SubscriberEntity("subscriberName", new EventEntity(eventName))
                 .AddWebhookEndpoint(new EndpointEntity(
                     "http://test",
                     new AuthenticationEntity(
@@ -372,7 +372,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 WebhookSelectionRule = "rule",
                 Endpoints = new EndpointSubdocument[] { }
             };
-            var subscriber = new SubscriberEntity("subscriberName", "rule", new EventEntity("eventName"));
+            var subscriber = new SubscriberEntity("subscriberName", new EventEntity("eventName"));
             _cosmosDbRepositoryMock
                 .Setup(x => x.CreateAsync(It.IsAny<SubscriberDocument>()))
                 .ReturnsAsync(new DocumentContainer<SubscriberDocument>(subscriberDocument,"etag"));
@@ -419,7 +419,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 WebhookSelectionRule = "rule",
                 Endpoints = new EndpointSubdocument[] { }
             };
-            var subscriber = new SubscriberEntity("subscriberName", "rule", new EventEntity("eventName"));
+            var subscriber = new SubscriberEntity("subscriberName", new EventEntity("eventName"));
             _cosmosDbRepositoryMock
                 .Setup(x => x.CreateAsync(It.IsAny<SubscriberDocument>()))
                 .ThrowsAsync(new CosmosException(string.Empty, System.Net.HttpStatusCode.Conflict, 0, string.Empty, 0));

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberDtoBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberDtoBuilder.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using CaptainHook.Contract;
+
+namespace CaptainHook.TestsInfrastructure.Builders
+{
+    public class SubscriberDtoBuilder: SimpleBuilder<SubscriberDto>
+    {
+        public SubscriberDtoBuilder()
+        {
+            With(
+                s => s.Webhooks,
+                new WebhooksDto
+                {
+                    SelectionRule = "$.TestSelector",
+                    Endpoints = new List<EndpointDto>
+                    {
+                        new EndpointDtoBuilder().Create()
+                    }
+                });
+        }
+    }
+}


### PR DESCRIPTION
### What
The new handler is added. We have noticed that it is very similar to the Webhook Handler and it is likely that we are going to unify them at the next stage.

### Testing
Code works and stores to Cosmos however not all mapping might be valid at this stage. JSON to test with (example):
```json
{
  "webhooks": {
    "selectionRule": "$.TestSelector",
    "endpoints": [
      {
        "uri": "https://webhook.site/a86944ce-b402-493b-ae57-1d679da8d82b",
        "httpVerb": "POST",
        "authentication": {
          "type": "OIDC",
          "clientId": "abc",
          "uri": "https://webhook.site/a86944ce-b402-493b-ae57-1d679da8d82b",
          "clientSecret": {
            "vault": "abc-keyvault",
            "name": "event--1--webhookconfig--authenticationconfig--clientsecret"
          },
          "scopes": [
            "scope1"
          ]
        }
      }
    ]
  }
}
```