### PR TITLE
#78987 - handler to accept additional endpoints for subscriber

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/DirectorService/DirectorServiceProxy.cs
+++ b/src/CaptainHook.Application.Infrastructure/DirectorService/DirectorServiceProxy.cs
@@ -33,5 +33,10 @@ namespace CaptainHook.Application.Infrastructure.DirectorService
                 _ => new BusinessError("Director Service returned unknown result.")
             };
         }
+
+        public Task<OperationResult<bool>> UpdateReaderAsync(SubscriberEntity subscriber)
+        {
+            return Task.FromResult(new OperationResult<bool>(true));
+        }
     }
 }

--- a/src/CaptainHook.Application.Infrastructure/DirectorService/IDirectorServiceProxy.cs
+++ b/src/CaptainHook.Application.Infrastructure/DirectorService/IDirectorServiceProxy.cs
@@ -5,7 +5,7 @@ using CaptainHook.Domain.Results;
 namespace CaptainHook.Application.Infrastructure.DirectorService
 {
     /// <summary>
-    /// A Gateway to Director Service
+    /// Proxy to Director Service
     /// </summary>
     public interface IDirectorServiceProxy
     {
@@ -17,8 +17,20 @@ namespace CaptainHook.Application.Infrastructure.DirectorService
         /// True if creation has been invoked
         /// False if reader already exists
         /// ReaderCreationError if reader creation failed
-        /// DirectorServiceIsBusyError if DirectorService is performing other operation
+        /// DirectorServiceIsBusyError if DirectorService is performing another operation
         /// </returns>
         Task<OperationResult<bool>> CreateReaderAsync(SubscriberEntity subscriber);
+
+        /// <summary>
+        /// Updates reader service for the given subscriber.
+        /// </summary>
+        /// <param name="subscriber">Subscriber entity defining ReaderService to be updated</param>
+        /// <returns>
+        /// True if update has been invoked
+        /// False if reader does not exist
+        /// ReaderUpdateError if reader update failed
+        /// DirectorServiceIsBusyError if DirectorService is performing another operation
+        /// </returns>
+        Task<OperationResult<bool>> UpdateReaderAsync(SubscriberEntity subscriber);
     }
 }

--- a/src/CaptainHook.Domain/Repositories/ISubscriberRepository.cs
+++ b/src/CaptainHook.Domain/Repositories/ISubscriberRepository.cs
@@ -14,26 +14,33 @@ namespace CaptainHook.Domain.Repositories
         /// </summary>
         /// <param name="eventName">The event name</param>
         /// <returns></returns>
-        public Task<OperationResult<IEnumerable<SubscriberEntity>>> GetSubscribersListAsync(string eventName);
+        Task<OperationResult<IEnumerable<SubscriberEntity>>> GetSubscribersListAsync(string eventName);
 
         /// <summary>
         /// Get particular subscriber for a specified event
         /// </summary>
         /// <param name="subscriberId">The id of the subscriber</param>
         /// <returns></returns>
-        public Task<OperationResult<SubscriberEntity>> GetSubscriberAsync(SubscriberId subscriberId);
+        Task<OperationResult<SubscriberEntity>> GetSubscriberAsync(SubscriberId subscriberId);
 
         /// <summary>
         /// Get all the subscribers
         /// </summary>
         /// <returns></returns>
-        public Task<OperationResult<IEnumerable<SubscriberEntity>>> GetAllSubscribersAsync();
+        Task<OperationResult<IEnumerable<SubscriberEntity>>> GetAllSubscribersAsync();
 
         /// <summary>
         /// Saves Subscriber
         /// </summary>
         /// <param name="subscriberEntity">Subscriber entity to Save</param>
         /// <returns></returns>
-        public Task<OperationResult<SubscriberEntity>> AddSubscriberAsync(SubscriberEntity subscriberEntity);
+        Task<OperationResult<SubscriberEntity>> AddSubscriberAsync(SubscriberEntity subscriberEntity);
+
+        /// <summary>
+        /// Updates subscriber
+        /// </summary>
+        /// <param name="subscriber">Subscriber to update</param>
+        /// <returns>Subscriber which has been updated</returns>
+        Task<OperationResult<SubscriberEntity>> UpdateSubscriberAsync(SubscriberEntity subscriber);
     }
 }

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -102,6 +102,11 @@ namespace CaptainHook.Storage.Cosmos
             return materialized;
         }
 
+        public Task<OperationResult<SubscriberEntity>> UpdateSubscriberAsync(SubscriberEntity subscriber)
+        {
+            return Task.FromResult(new OperationResult<SubscriberEntity>(subscriber));
+        }
+
         #region Private methods
 
         private async Task<SubscriberEntity> AddSubscriberInternalAsync(SubscriberEntity subscriberEntity)


### PR DESCRIPTION
Handler gets extended so that it can handle both Additions and Updates. Updates always go through but do not have any effect in Director Service or Cosmos just yet.