### PR TITLE
Return appropriate error when config has not been fully loaded yet

### DIFF
--- a/src/CaptainHook.Api/Controllers/SubscribersController.cs
+++ b/src/CaptainHook.Api/Controllers/SubscribersController.cs
@@ -39,8 +39,12 @@ namespace CaptainHook.Api.Controllers
         /// Retrieve all subscribers from current configuration
         /// </summary>
         /// <response code="200">Subscribers retrieved properly</response>
+        /// <response code="503">Configuration has not been fully loaded yet</response>
+        /// <response code="500">An error occurred while processing the request</response>
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetAll()
         {
             try
@@ -49,14 +53,19 @@ namespace CaptainHook.Api.Controllers
                 var directorServiceClient = ServiceProxy.Create<IDirectorServiceRemoting>(directorServiceUri);
                 var subscribers = await directorServiceClient.GetAllSubscribersAsync();
 
+                if(subscribers == null)
+                {
+                    return StatusCode(StatusCodes.Status503ServiceUnavailable);
+                }
+
                 AuthenticationConfigSanitizer.Sanitize(subscribers.Values);
 
                 return Ok(subscribers);
             }
             catch (Exception exception)
             {
-                _bigBrother.Publish(exception);
-                return BadRequest();
+                _bigBrother.Publish(exception.ToExceptionEvent());
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }
     }


### PR DESCRIPTION
Quick PR to address stuff I stumbled upon while working on something else:
- Return 500 when there's an exception (400 bad request has a different meaning)
- Correctly use ToExceptionEvent to log BB exception
- Return 503 when director has not completed loading of config (config is unavailable, subscribers is null, then we would be getting a 400)
- Set Swagger response descriptions