### PR TITLE
#78991 - start using eTags for updates in Cosmos DB

### DIFF
--- a/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
+++ b/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
@@ -24,6 +24,11 @@ namespace CaptainHook.Domain.Entities
         public string Name { get; }
 
         /// <summary>
+        /// Gets the version of the entity.
+        /// </summary>
+        public string Etag { get; }
+
+        /// <summary>
         /// Parent event for this subscriber
         /// </summary>
         public EventEntity ParentEvent { get; private set; }
@@ -33,10 +38,10 @@ namespace CaptainHook.Domain.Entities
         /// </summary>
         public WebhooksEntity Webhooks { get; private set; }
 
-        public SubscriberEntity(string name) : this(name, null) { }
-        public SubscriberEntity(string name, EventEntity parentEvent)
+        public SubscriberEntity(string name, EventEntity parentEvent = null, string etag = null)
         {
             Name = name;
+            Etag = etag;
             SetParentEvent(parentEvent);
         }
 

--- a/src/CaptainHook.Storage.Cosmos/Models/SubscriberDocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/SubscriberDocument.cs
@@ -46,5 +46,11 @@ namespace CaptainHook.Storage.Cosmos.Models
         /// </summary>
         [JsonProperty("webhooks")]
         public WebhookSubdocument Webhooks { get; set; }
+
+        /// <summary>
+        /// ETag of the document from Cosmos Db
+        /// </summary>
+        [JsonProperty("_etag")]
+        public string Etag { get; set; }
     }
 }

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -109,7 +109,7 @@ namespace CaptainHook.Storage.Cosmos
             {
                 var subscriberDocument = Map(subscriberEntity);
 
-                var result = await _cosmosDbRepository.ReplaceAsync(subscriberDocument.Id, subscriberDocument);
+                var result = await _cosmosDbRepository.ReplaceAsync(subscriberDocument.Id, subscriberDocument, subscriberEntity.Etag);
                 return Map(result.Document);
             }
             catch (Exception exception)
@@ -184,7 +184,8 @@ namespace CaptainHook.Storage.Cosmos
                 Id = subscriberEntity.Id,
                 EventName = subscriberEntity.ParentEvent.Name,
                 SubscriberName = subscriberEntity.Name,
-                Webhooks = Map(subscriberEntity.Webhooks)
+                Webhooks = Map(subscriberEntity.Webhooks),
+                Etag = subscriberEntity.Etag
             };
         }
 
@@ -224,7 +225,8 @@ namespace CaptainHook.Storage.Cosmos
 
             var subscriberEntity = new SubscriberEntity(
                 subscriberDocument.SubscriberName,
-                eventEntity);
+                eventEntity,
+                subscriberDocument.Etag);
 
             subscriberEntity.AddWebhooks(Map(subscriberDocument.Webhooks, subscriberEntity));
 

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -184,8 +184,7 @@ namespace CaptainHook.Storage.Cosmos
                 Id = subscriberEntity.Id,
                 EventName = subscriberEntity.ParentEvent.Name,
                 SubscriberName = subscriberEntity.Name,
-                Webhooks = Map(subscriberEntity.Webhooks),
-                Etag = subscriberEntity.Etag
+                Webhooks = Map(subscriberEntity.Webhooks)
             };
         }
 

--- a/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
+++ b/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
@@ -470,8 +470,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 {
                     SelectionRule = "rule",
                     Endpoints = new EndpointSubdocument[] { }
-                },
-                Etag = "version1"
+                }
             };
 
             subscriber.AddWebhooks(new WebhooksEntity("rule"));

--- a/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
+++ b/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
@@ -87,13 +87,14 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 {
                     SelectionRule = "rule",
                     Endpoints = new[] { endpoint }
-                }
+                },
+                Etag = "version1"
             };
             _cosmosDbRepositoryMock
                 .Setup(x => x.QueryAsync<SubscriberDocument>(It.IsAny<CosmosQuery>()))
                 .ReturnsAsync(new List<SubscriberDocument> { sampleDocument });
 
-            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, new EventEntity(eventName));
+            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, new EventEntity(eventName), "version1");
             var sampleAuthStoreEntity = new SecretStoreEntity(endpoint.Authentication.KeyVaultName, endpoint.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(endpoint.Authentication.ClientId, sampleAuthStoreEntity, endpoint.Authentication.Uri, endpoint.Authentication.Type, endpoint.Authentication.Scopes);
             var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.Selector);
@@ -260,13 +261,14 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 {
                     SelectionRule = "rule",
                     Endpoints = new[] { endpoint }
-                }
+                },
+                Etag = "version1"
             };
             _cosmosDbRepositoryMock
                 .Setup(x => x.QueryAsync<SubscriberDocument>(It.IsAny<CosmosQuery>()))
                 .ReturnsAsync(new List<SubscriberDocument> { sampleDocument });
 
-            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, new EventEntity(eventName));
+            var expectedSubscriberEntity = new SubscriberEntity(sampleDocument.SubscriberName, new EventEntity(eventName), "version1");
             var sampleAuthStoreEntity = new SecretStoreEntity(endpoint.Authentication.KeyVaultName, endpoint.Authentication.SecretName);
             var expectedAuthenticationEntity = new AuthenticationEntity(endpoint.Authentication.ClientId, sampleAuthStoreEntity, endpoint.Authentication.Uri, endpoint.Authentication.Type, endpoint.Authentication.Scopes);
             var expectedEndpointEntity = new EndpointEntity(endpoint.Uri, expectedAuthenticationEntity, endpoint.HttpVerb, endpoint.Selector);
@@ -457,7 +459,7 @@ namespace CaptainHook.Storage.Cosmos.Tests
         public async Task UpdateSubscriberAsync_WithValidSubscriber_CallsRepoWithCorrectDocument()
         {
             // Arrange            
-            var subscriber = new SubscriberEntity("subscriberName", new EventEntity("eventName"));
+            var subscriber = new SubscriberEntity("subscriberName", new EventEntity("eventName"), "version1");
             var subscriberId = subscriber.Id.ToString();
             var subscriberDocument = new SubscriberDocument
             {
@@ -468,13 +470,11 @@ namespace CaptainHook.Storage.Cosmos.Tests
                 {
                     SelectionRule = "rule",
                     Endpoints = new EndpointSubdocument[] { }
-                }
+                },
+                Etag = "version1"
             };
 
             subscriber.AddWebhooks(new WebhooksEntity("rule"));
-            _cosmosDbRepositoryMock
-                .Setup(x => x.ReplaceAsync(It.IsAny<string>(), It.IsAny<SubscriberDocument>(), null))
-                .ReturnsAsync(new DocumentContainer<SubscriberDocument>(subscriberDocument, null));
 
             // Act
             await _repository.UpdateSubscriberAsync(subscriber);
@@ -487,9 +487,9 @@ namespace CaptainHook.Storage.Cosmos.Tests
             };
 
             _cosmosDbRepositoryMock.Verify(x => x.ReplaceAsync(
-                subscriberId, 
-                It.Is<SubscriberDocument>(arg => validate(arg)), 
-                null), Times.Once);
+                subscriberId,
+                It.Is<SubscriberDocument>(arg => validate(arg)),
+                "version1"), Times.Once);
         }
 
         [Fact, IsUnit]


### PR DESCRIPTION
### What
Start using eTags for document updates/replacements. Further logic to address failures for updates is going to be addressed in a separate PR.