### PR TITLE
#78993 - support retries for Upsert Webhook Request

### DIFF
--- a/src/CaptainHook.Application/CaptainHook.Application.csproj
+++ b/src/CaptainHook.Application/CaptainHook.Application.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -9,6 +9,7 @@
     <PackageReference Include="FluentValidation" Version="9.0.1" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Application.Infrastructure.DirectorService;
@@ -10,25 +10,38 @@ using CaptainHook.Domain.Repositories;
 using CaptainHook.Domain.Results;
 using CaptainHook.Domain.ValueObjects;
 using MediatR;
+using Polly;
 
 namespace CaptainHook.Application.Handlers.Subscribers
 {
     public class UpsertWebhookRequestHandler : IRequestHandler<UpsertWebhookRequest, OperationResult<EndpointDto>>
     {
+        private static readonly TimeSpan[] DefaultRetrySleepDurations = {
+            TimeSpan.FromSeconds(1.0),
+            TimeSpan.FromSeconds(2.0),
+        };
+
         private readonly ISubscriberRepository _subscriberRepository;
+
         private readonly IDirectorServiceProxy _directorService;
 
-        public UpsertWebhookRequestHandler(ISubscriberRepository subscriberRepository,
-            IDirectorServiceProxy directorService)
+        private readonly TimeSpan[] _retrySleepDurations;
+
+        public UpsertWebhookRequestHandler(
+            ISubscriberRepository subscriberRepository,
+            IDirectorServiceProxy directorService,
+            TimeSpan[] _sleepDurations = null)
         {
             _subscriberRepository = subscriberRepository;
             _directorService = directorService;
+            _retrySleepDurations = _sleepDurations ?? DefaultRetrySleepDurations;
         }
 
-        public async Task<OperationResult<EndpointDto>> Handle(UpsertWebhookRequest request,
+        public async Task<OperationResult<EndpointDto>> Handle(
+            UpsertWebhookRequest request,
             CancellationToken cancellationToken)
         {
-            try
+            async Task<OperationResult<EndpointDto>> AddOrUpdateEndpointAsync()
             {
                 var subscriberId = new SubscriberId(request.EventName, request.SubscriberName);
                 var existingItem = await _subscriberRepository.GetSubscriberAsync(subscriberId);
@@ -38,12 +51,22 @@ namespace CaptainHook.Application.Handlers.Subscribers
                     return await AddAsync(request, cancellationToken);
                 }
 
-                if (!existingItem.IsError)
+                if (! existingItem.IsError)
                 {
-                    return await UpdateAsync(request, existingItem.Data, cancellationToken);
+                    return await UpdateAsync(request, existingItem.Data);
                 }
 
                 return existingItem.Error;
+            }
+
+            try
+            {
+                var executionResult = await Policy
+                    .HandleResult<OperationResult<EndpointDto>>(result => result.Error is CannotUpdateEntityError)
+                    .WaitAndRetryAsync(_retrySleepDurations)
+                    .ExecuteAsync(AddOrUpdateEndpointAsync);
+
+                return executionResult;
             }
             catch (Exception ex)
             {
@@ -74,8 +97,7 @@ namespace CaptainHook.Application.Handlers.Subscribers
 
         private async Task<OperationResult<EndpointDto>> UpdateAsync(
             UpsertWebhookRequest request,
-            SubscriberEntity existingItem,
-            CancellationToken cancellationToken)
+            SubscriberEntity existingItem)
         {
             var endpoint = MapRequestToEndpoint(request, existingItem);
             var addWebhookResult = existingItem.AddWebhookEndpoint(endpoint);
@@ -98,8 +120,6 @@ namespace CaptainHook.Application.Handlers.Subscribers
             }
 
             return request.Endpoint;
-
-            //repeat if error
         }
 
         private static EndpointEntity MapRequestToEndpoint(UpsertWebhookRequest request, SubscriberEntity parent)

--- a/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
@@ -9,6 +9,7 @@ using CaptainHook.Domain.Errors;
 using CaptainHook.Domain.Repositories;
 using CaptainHook.Domain.Results;
 using CaptainHook.Domain.ValueObjects;
+using Eshopworld.Core;
 using MediatR;
 using Polly;
 
@@ -25,15 +26,19 @@ namespace CaptainHook.Application.Handlers.Subscribers
 
         private readonly IDirectorServiceProxy _directorService;
 
+        private readonly IBigBrother _bigBrother;
+
         private readonly TimeSpan[] _retrySleepDurations;
 
         public UpsertWebhookRequestHandler(
             ISubscriberRepository subscriberRepository,
             IDirectorServiceProxy directorService,
+            IBigBrother bigBrother,
             TimeSpan[] _sleepDurations = null)
         {
             _subscriberRepository = subscriberRepository;
             _directorService = directorService;
+            _bigBrother = bigBrother;
             _retrySleepDurations = _sleepDurations ?? DefaultRetrySleepDurations;
         }
 
@@ -70,6 +75,7 @@ namespace CaptainHook.Application.Handlers.Subscribers
             }
             catch (Exception ex)
             {
+                _bigBrother.Publish(ex.ToExceptionEvent());
                 return new UnhandledExceptionError($"Error processing {nameof(UpsertWebhookRequest)}", ex);
             }
         }

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/UpsertWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/UpsertWebhookRequestHandlerTests.cs
@@ -13,10 +13,10 @@ using CaptainHook.Domain.Repositories;
 using CaptainHook.Domain.Results;
 using CaptainHook.Domain.ValueObjects;
 using CaptainHook.TestsInfrastructure.Builders;
+using Eshopworld.Core;
 using Eshopworld.Tests.Core;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using FluentValidation;
 using Moq;
 using Xunit;
 
@@ -28,12 +28,10 @@ namespace CaptainHook.Application.Tests.Handlers
 
         private readonly Mock<IDirectorServiceProxy> _directorServiceMock = new Mock<IDirectorServiceProxy>();
 
-        private readonly Mock<IValidator<SubscriberEntity>> _subscriberValidatorMock =
-            new Mock<IValidator<SubscriberEntity>>();
-
         private UpsertWebhookRequestHandler Handler => new UpsertWebhookRequestHandler(
             _repositoryMock.Object,
-            _directorServiceMock.Object,
+            _directorServiceMock.Object, 
+            Mock.Of<IBigBrother>(),
             new[]
             {
                 TimeSpan.FromMilliseconds(10.0),


### PR DESCRIPTION
### What
Operations are retried if there is a problem when updating the document in Cosmos (changes in between and eTag check fails). Please note this also applies to the subscriber being removed entirely, in that case, we will re-add it with a single endpoint.