### PR TITLE
Override selector replace transform with selection rule and unit test

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
@@ -60,9 +60,9 @@ namespace CaptainHook.Application.Infrastructure.Mappers
             var replacements = entity.Webhooks.Endpoints
                 .Where(x => x.UriTransform?.Replace != null)
                 .SelectMany(x => x.UriTransform.Replace)
-                .GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
+                .GroupBy(x => x.Key)
                 .Select(x => x.First())
-                .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+                .ToDictionary(x => x.Key, x => x.Value);
 
             replacements["selector"] = entity.Webhooks.SelectionRule;
 

--- a/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
@@ -58,6 +58,7 @@ namespace CaptainHook.Application.Infrastructure.Mappers
         private async Task<SubscriberConfiguration> MapForUriTransformAsync(SubscriberEntity entity)
         {
             var replacements = entity.Webhooks.Endpoints
+                .Where(x => x.UriTransform?.Replace != null)
                 .SelectMany(x => x.UriTransform.Replace)
                 .GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
                 .Select(x => x.First())

--- a/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,13 +57,13 @@ namespace CaptainHook.Application.Infrastructure.Mappers
 
         private async Task<SubscriberConfiguration> MapForUriTransformAsync(SubscriberEntity entity)
         {
-            var replacements = new Dictionary<string, string>(entity.Webhooks.Endpoints
+            var replacements = entity.Webhooks.Endpoints
                 .SelectMany(x => x.UriTransform.Replace)
-                .GroupBy(x => x.Key)
-                .Select(x => x.First()))
-            {
-                { "selector", entity.Webhooks.SelectionRule }
-            };
+                .GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(x => x.First())
+                .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+
+            replacements["selector"] = entity.Webhooks.SelectionRule;
 
             var routes = await MapWebhooksToRoutesAsync(entity.Webhooks);
 


### PR DESCRIPTION
- Use a case insensitive comparison when finding duplicates in the URI transform replacement dictionary
- Use a case insensitive comparer when building the aggregate dictionary so the subsequent override of the selector key will work as expected in any case
- Override the selector replacement in the URI transform with the selectionRule