### PR TITLE
Added 401 response type annotation. Regenerated client.

### DIFF
--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
@@ -1126,7 +1126,7 @@ namespace CaptainHook.Api.Client
             HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
-            if ((int)_statusCode != 200 && (int)_statusCode != 500 && (int)_statusCode != 503)
+            if ((int)_statusCode != 200 && (int)_statusCode != 401 && (int)_statusCode != 500 && (int)_statusCode != 503)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
                 if (_httpResponse.Content != null) {

--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
@@ -1021,7 +1021,7 @@ namespace CaptainHook.Api.Client
             HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
-            if ((int)_statusCode != 202 && (int)_statusCode != 400 && (int)_statusCode != 409)
+            if ((int)_statusCode != 202 && (int)_statusCode != 400 && (int)_statusCode != 401 && (int)_statusCode != 409)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
                 if (_httpResponse.Content != null) {

--- a/src/CaptainHook.Api/Controllers/RefreshConfigController.cs
+++ b/src/CaptainHook.Api/Controllers/RefreshConfigController.cs
@@ -35,10 +35,12 @@ namespace CaptainHook.Api.Controllers
         /// <response code="202">Configuration reload has been requested</response>
         /// <response code="400">Configuration reload has not been requested due to an error</response>
         /// <response code="409">Configuration reload has not been requested as another reload is in progress</response>
+        /// <response code="401">Request not authorized</response>
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status202Accepted)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> ReloadConfiguration()
         {
             try

--- a/src/CaptainHook.Api/Controllers/SubscribersController.cs
+++ b/src/CaptainHook.Api/Controllers/SubscribersController.cs
@@ -41,7 +41,7 @@ namespace CaptainHook.Api.Controllers
         /// <response code="200">Subscribers retrieved properly</response>
         /// <response code="503">Configuration has not been fully loaded yet</response>
         /// <response code="500">An error occurred while processing the request</response>
-        /// <response code="401">An error occurred while processing the request</response>
+        /// <response code="401">Request not authorized</response>
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]

--- a/src/CaptainHook.Api/Controllers/SubscribersController.cs
+++ b/src/CaptainHook.Api/Controllers/SubscribersController.cs
@@ -41,10 +41,12 @@ namespace CaptainHook.Api.Controllers
         /// <response code="200">Subscribers retrieved properly</response>
         /// <response code="503">Configuration has not been fully loaded yet</response>
         /// <response code="500">An error occurred while processing the request</response>
+        /// <response code="401">An error occurred while processing the request</response>
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> GetAll()
         {
             try


### PR DESCRIPTION
Background - The 401 is part of the GetAll API behavior but not the documentation (swagger.json) due to the missing annotation. This makes the CaptainHook.Api.Client throw an exception when 401 is returned and the tests fail.