### PR TITLE
#80130 - use endpoint selector if no selection rule provided

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
@@ -64,7 +64,10 @@ namespace CaptainHook.Application.Infrastructure.Mappers
                 .Select(x => x.First())
                 .ToDictionary(x => x.Key, x => x.Value);
 
-            replacements["selector"] = entity.Webhooks.SelectionRule;
+            if (!string.IsNullOrEmpty(entity.Webhooks.SelectionRule))
+            {
+                replacements["selector"] = entity.Webhooks.SelectionRule;
+            }
 
             var routes = await MapWebhooksToRoutesAsync(entity.Webhooks);
 


### PR DESCRIPTION
### What
The lack of this broke insert of a webhook for a new subscriber (when a new subscriber is created from webhook PUT endpoint).