### PR TITLE
Skip refresh config on builds

### DIFF
--- a/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
@@ -17,7 +17,8 @@ namespace CaptainHook.Api.Tests
         {
         }
 
-        [Fact, IsIntegration]
+
+        [Fact(Skip = "A successful RefreshConfig makes the other tests fail until refresh is complete"), IsIntegration]
         public async Task RefreshConfig_WhenAuthenticated_Returns202Accepted()
         {
             var result = await AuthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();

--- a/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
@@ -18,7 +18,7 @@ namespace CaptainHook.Api.Tests
         }
 
 
-        [Fact(Skip = "A successful RefreshConfig makes the other tests fail until refresh is complete"), IsIntegration]
+        [Fact(Skip = "Skipped: a successful RefreshConfig makes the other tests fail until refresh is complete."), IsIntegration]
         public async Task RefreshConfig_WhenAuthenticated_Returns202Accepted()
         {
             var result = await AuthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();


### PR DESCRIPTION
The CI deployment fails due to failed integration tests.