### PR TITLE
Fix Subscribers loading issue

### DIFF
--- a/src/CaptainHook.Api/Controllers/EventsController.cs
+++ b/src/CaptainHook.Api/Controllers/EventsController.cs
@@ -7,7 +7,6 @@ using CaptainHook.Domain.Errors;
 using CaptainHook.Domain.Results;
 using Eshopworld.Core;
 using MediatR;
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/CaptainHook.Api/Controllers/SubscribersController.cs
+++ b/src/CaptainHook.Api/Controllers/SubscribersController.cs
@@ -5,6 +5,7 @@ using CaptainHook.Application.Infrastructure.DirectorService.Remoting;
 using CaptainHook.Common;
 using CaptainHook.Common.Configuration;
 using Eshopworld.Core;
+using Kusto.Cloud.Platform.Utils;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -55,7 +56,7 @@ namespace CaptainHook.Api.Controllers
                 var directorServiceClient = ServiceProxy.Create<IDirectorServiceRemoting>(directorServiceUri);
                 var subscribers = await directorServiceClient.GetAllSubscribersAsync();
 
-                if(subscribers == null)
+                if(subscribers.Count == 0)
                 {
                     return StatusCode(StatusCodes.Status503ServiceUnavailable);
                 }


### PR DESCRIPTION
The GetAll Subscribers API had a check in place to ensure the Director service completed the loading of subscribers before returning a result. This check was relying on the subscribers dictionary being null while the loading is still in progress. Then the API could reply with a 503 informing the user the load had not been completed yet. This scenario applies when starting the application.

This check was broken by a subsequent commit which initialized the subscriber with an empty Dictionary.

This PR address this issue by checking for an empty dictionary instead of null.

This is not an ideal situation as an empty Dictionary could still be a valid dictionary.