### PR TITLE
Task 80579 extend ch api with reload status

### DIFF
--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
@@ -309,6 +309,216 @@ namespace CaptainHook.Api.Client
             CustomInitialize();
         }
         /// <summary>
+        /// Reloads configuration for Captain Hook
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse> ReloadWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "Reload", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = BaseUri.AbsoluteUri;
+            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/config/reload").ToString();
+            // Create HTTP transport objects
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
+            _httpRequest.RequestUri = new System.Uri(_url);
+            // Set Headers
+
+
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Set Credentials
+            if (Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 202 && (int)_statusCode != 400 && (int)_statusCode != 401 && (int)_statusCode != 409)
+            {
+                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Returns whether an existing configuration reload request is in progress
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse> GetStatusWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetStatus", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = BaseUri.AbsoluteUri;
+            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/config/status").ToString();
+            // Create HTTP transport objects
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new System.Uri(_url);
+            // Set Headers
+
+
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Set Credentials
+            if (Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200 && (int)_statusCode != 202 && (int)_statusCode != 400 && (int)_statusCode != 401)
+            {
+                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
         /// Insert or update a web hook
         /// </summary>
         /// <param name='eventName'>
@@ -917,111 +1127,6 @@ namespace CaptainHook.Api.Client
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
-            {
-                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                if (_httpResponse.Content != null) {
-                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                }
-                else {
-                    _responseContent = string.Empty;
-                }
-                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
-                if (_shouldTrace)
-                {
-                    ServiceClientTracing.Error(_invocationId, ex);
-                }
-                _httpRequest.Dispose();
-                if (_httpResponse != null)
-                {
-                    _httpResponse.Dispose();
-                }
-                throw ex;
-            }
-            // Create Result
-            var _result = new HttpOperationResponse();
-            _result.Request = _httpRequest;
-            _result.Response = _httpResponse;
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.Exit(_invocationId, _result);
-            }
-            return _result;
-        }
-
-        /// <summary>
-        /// Reloads configuration for Captain Hook
-        /// </summary>
-        /// <param name='customHeaders'>
-        /// Headers that will be added to request.
-        /// </param>
-        /// <param name='cancellationToken'>
-        /// The cancellation token.
-        /// </param>
-        /// <exception cref="HttpOperationException">
-        /// Thrown when the operation returned an invalid status code
-        /// </exception>
-        /// <return>
-        /// A response object containing the response body and response headers.
-        /// </return>
-        public async Task<HttpOperationResponse> ReloadConfigurationWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            // Tracing
-            bool _shouldTrace = ServiceClientTracing.IsEnabled;
-            string _invocationId = null;
-            if (_shouldTrace)
-            {
-                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
-                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
-                tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(_invocationId, this, "ReloadConfiguration", tracingParameters);
-            }
-            // Construct URL
-            var _baseUrl = BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/refresh-config").ToString();
-            // Create HTTP transport objects
-            var _httpRequest = new HttpRequestMessage();
-            HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new HttpMethod("POST");
-            _httpRequest.RequestUri = new System.Uri(_url);
-            // Set Headers
-
-
-            if (customHeaders != null)
-            {
-                foreach(var _header in customHeaders)
-                {
-                    if (_httpRequest.Headers.Contains(_header.Key))
-                    {
-                        _httpRequest.Headers.Remove(_header.Key);
-                    }
-                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
-                }
-            }
-
-            // Serialize Request
-            string _requestContent = null;
-            // Set Credentials
-            if (Credentials != null)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                await Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
-            }
-            // Send Request
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
-            }
-            cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
-            }
-            HttpStatusCode _statusCode = _httpResponse.StatusCode;
-            cancellationToken.ThrowIfCancellationRequested();
-            string _responseContent = null;
-            if ((int)_statusCode != 202 && (int)_statusCode != 400 && (int)_statusCode != 401 && (int)_statusCode != 409)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
                 if (_httpResponse.Content != null) {

--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
@@ -323,7 +323,7 @@ namespace CaptainHook.Api.Client
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse> ReloadWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse> ReloadConfigurationWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
@@ -333,7 +333,7 @@ namespace CaptainHook.Api.Client
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(_invocationId, this, "Reload", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ReloadConfiguration", tracingParameters);
             }
             // Construct URL
             var _baseUrl = BaseUri.AbsoluteUri;
@@ -428,7 +428,7 @@ namespace CaptainHook.Api.Client
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse> GetStatusWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse> GetConfigurationStatusWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
@@ -438,7 +438,7 @@ namespace CaptainHook.Api.Client
                 _invocationId = ServiceClientTracing.NextInvocationId.ToString();
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(_invocationId, this, "GetStatus", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetConfigurationStatus", tracingParameters);
             }
             // Construct URL
             var _baseUrl = BaseUri.AbsoluteUri;

--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClientExtensions.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClientExtensions.cs
@@ -24,9 +24,9 @@ namespace CaptainHook.Api.Client
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
-            public static void Reload(this ICaptainHookClient operations)
+            public static void ReloadConfiguration(this ICaptainHookClient operations)
             {
-                operations.ReloadAsync().GetAwaiter().GetResult();
+                operations.ReloadConfigurationAsync().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -38,9 +38,9 @@ namespace CaptainHook.Api.Client
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task ReloadAsync(this ICaptainHookClient operations, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task ReloadConfigurationAsync(this ICaptainHookClient operations, CancellationToken cancellationToken = default(CancellationToken))
             {
-                (await operations.ReloadWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
+                (await operations.ReloadConfigurationWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
             /// <summary>
@@ -52,9 +52,9 @@ namespace CaptainHook.Api.Client
             /// <param name='customHeaders'>
             /// Headers that will be added to request.
             /// </param>
-            public static HttpOperationResponse ReloadWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
+            public static HttpOperationResponse ReloadConfigurationWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
             {
-                return operations.ReloadWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+                return operations.ReloadConfigurationWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -63,9 +63,9 @@ namespace CaptainHook.Api.Client
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
-            public static void GetStatus(this ICaptainHookClient operations)
+            public static void GetConfigurationStatus(this ICaptainHookClient operations)
             {
-                operations.GetStatusAsync().GetAwaiter().GetResult();
+                operations.GetConfigurationStatusAsync().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -77,9 +77,9 @@ namespace CaptainHook.Api.Client
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task GetStatusAsync(this ICaptainHookClient operations, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task GetConfigurationStatusAsync(this ICaptainHookClient operations, CancellationToken cancellationToken = default(CancellationToken))
             {
-                (await operations.GetStatusWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
+                (await operations.GetConfigurationStatusWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
             }
 
             /// <summary>
@@ -91,9 +91,9 @@ namespace CaptainHook.Api.Client
             /// <param name='customHeaders'>
             /// Headers that will be added to request.
             /// </param>
-            public static HttpOperationResponse GetStatusWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
+            public static HttpOperationResponse GetConfigurationStatusWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
             {
-                return operations.GetStatusWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+                return operations.GetConfigurationStatusWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
             /// <summary>

--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClientExtensions.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClientExtensions.cs
@@ -19,6 +19,84 @@ namespace CaptainHook.Api.Client
     public static partial class CaptainHookClientExtensions
     {
             /// <summary>
+            /// Reloads configuration for Captain Hook
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static void Reload(this ICaptainHookClient operations)
+            {
+                operations.ReloadAsync().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Reloads configuration for Captain Hook
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task ReloadAsync(this ICaptainHookClient operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                (await operations.ReloadWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
+            }
+
+            /// <summary>
+            /// Reloads configuration for Captain Hook
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='customHeaders'>
+            /// Headers that will be added to request.
+            /// </param>
+            public static HttpOperationResponse ReloadWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
+            {
+                return operations.ReloadWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Returns whether an existing configuration reload request is in progress
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            public static void GetStatus(this ICaptainHookClient operations)
+            {
+                operations.GetStatusAsync().GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Returns whether an existing configuration reload request is in progress
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task GetStatusAsync(this ICaptainHookClient operations, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                (await operations.GetStatusWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
+            }
+
+            /// <summary>
+            /// Returns whether an existing configuration reload request is in progress
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='customHeaders'>
+            /// Headers that will be added to request.
+            /// </param>
+            public static HttpOperationResponse GetStatusWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
+            {
+                return operations.GetStatusWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+
+            /// <summary>
             /// Insert or update a web hook
             /// </summary>
             /// <param name='operations'>
@@ -193,45 +271,6 @@ namespace CaptainHook.Api.Client
             public static HttpOperationResponse GetProbeWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
             {
                 return operations.GetProbeWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Reloads configuration for Captain Hook
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            public static void ReloadConfiguration(this ICaptainHookClient operations)
-            {
-                operations.ReloadConfigurationAsync().GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Reloads configuration for Captain Hook
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task ReloadConfigurationAsync(this ICaptainHookClient operations, CancellationToken cancellationToken = default(CancellationToken))
-            {
-                (await operations.ReloadConfigurationWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false)).Dispose();
-            }
-
-            /// <summary>
-            /// Reloads configuration for Captain Hook
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='customHeaders'>
-            /// Headers that will be added to request.
-            /// </param>
-            public static HttpOperationResponse ReloadConfigurationWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
-            {
-                return operations.ReloadConfigurationWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
             /// <summary>

--- a/src/CaptainHook.Api.Client/ApiClient/ICaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/ICaptainHookClient.cs
@@ -49,7 +49,7 @@ namespace CaptainHook.Api.Client
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<HttpOperationResponse> ReloadWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse> ReloadConfigurationWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Returns whether an existing configuration reload request is in
@@ -61,7 +61,7 @@ namespace CaptainHook.Api.Client
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<HttpOperationResponse> GetStatusWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse> GetConfigurationStatusWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Insert or update a web hook

--- a/src/CaptainHook.Api.Client/ApiClient/ICaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/ICaptainHookClient.cs
@@ -41,6 +41,29 @@ namespace CaptainHook.Api.Client
 
 
         /// <summary>
+        /// Reloads configuration for Captain Hook
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse> ReloadWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns whether an existing configuration reload request is in
+        /// progress
+        /// </summary>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse> GetStatusWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Insert or update a web hook
         /// </summary>
         /// <param name='eventName'>
@@ -90,17 +113,6 @@ namespace CaptainHook.Api.Client
         /// The cancellation token.
         /// </param>
         Task<HttpOperationResponse> GetProbeWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Reloads configuration for Captain Hook
-        /// </summary>
-        /// <param name='customHeaders'>
-        /// The headers that will be added to request.
-        /// </param>
-        /// <param name='cancellationToken'>
-        /// The cancellation token.
-        /// </param>
-        Task<HttpOperationResponse> ReloadConfigurationWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Retrieve all subscribers from current configuration

--- a/src/CaptainHook.Api/Controllers/ConfigurationController.cs
+++ b/src/CaptainHook.Api/Controllers/ConfigurationController.cs
@@ -41,7 +41,7 @@ namespace CaptainHook.Api.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<IActionResult> Reload()
+        public async Task<IActionResult> ReloadConfiguration()
         {
             try
             {
@@ -72,7 +72,7 @@ namespace CaptainHook.Api.Controllers
         [ProducesResponseType(StatusCodes.Status202Accepted)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<IActionResult> GetStatus()
+        public async Task<IActionResult> GetConfigurationStatus()
         {
             try
             {

--- a/src/CaptainHook.Api/Controllers/ConfigurationController.cs
+++ b/src/CaptainHook.Api/Controllers/ConfigurationController.cs
@@ -12,11 +12,11 @@ using Microsoft.ServiceFabric.Services.Remoting.Client;
 namespace CaptainHook.Api.Controllers
 {
     /// <summary>
-    /// Refresh configuration controller
+    /// Configuration controller
     /// </summary>
-    [Route("api/refresh-config")]
+    [Route("api/config")]
     [Authorize(Policy = AuthorisationPolicies.ReadSubscribers)]
-    public class RefreshConfigController: ControllerBase
+    public class ConfigurationController : ControllerBase
     {
         private readonly IBigBrother _bigBrother;
 
@@ -24,7 +24,7 @@ namespace CaptainHook.Api.Controllers
         /// Initializes a new instance of this class
         /// </summary>
         /// <param name="bigBrother">BigBrother instance</param>
-        public RefreshConfigController(IBigBrother bigBrother)
+        public ConfigurationController(IBigBrother bigBrother)
         {
             _bigBrother = bigBrother;
         }
@@ -36,12 +36,12 @@ namespace CaptainHook.Api.Controllers
         /// <response code="400">Configuration reload has not been requested due to an error</response>
         /// <response code="409">Configuration reload has not been requested as another reload is in progress</response>
         /// <response code="401">Request not authorized</response>
-        [HttpPost]
+        [HttpPost("reload")]
         [ProducesResponseType(StatusCodes.Status202Accepted)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task<IActionResult> ReloadConfiguration()
+        public async Task<IActionResult> Reload()
         {
             try
             {
@@ -50,8 +50,40 @@ namespace CaptainHook.Api.Controllers
                 var requestReloadConfigurationResult = await directorServiceClient.RequestReloadConfigurationAsync();
 
                 return requestReloadConfigurationResult == RequestReloadConfigurationResult.ReloadStarted
-                    ? (IActionResult) Accepted()
+                    ? (IActionResult)Accepted()
                     : Conflict();
+            }
+            catch (Exception exception)
+            {
+                _bigBrother.Publish(exception.ToExceptionEvent());
+                return BadRequest();
+            }
+        }
+
+        /// <summary>
+        /// Returns whether an existing configuration reload request is in progress
+        /// </summary>
+        /// <response code="200">Configuration reload is not in progress</response>
+        /// <response code="202">Configuration reload in progress</response>
+        /// <response code="400">Cannot get status due to an error</response>
+        /// <response code="401">Request not authorized</response>
+        [HttpGet("status")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> GetStatus()
+        {
+            try
+            {
+                var directorServiceUri = new Uri(ServiceNaming.DirectorServiceFullName);
+                var directorServiceClient = ServiceProxy.Create<IDirectorServiceRemoting>(directorServiceUri);
+                var result = await directorServiceClient.GetReloadConfigurationStatusAsync();
+                return result switch
+                {
+                    ReloadConfigurationStatus.InProgress => Accepted(),
+                    _ => Ok()
+                };
             }
             catch (Exception exception)
             {

--- a/src/CaptainHook.Api/Controllers/SubscribersController.cs
+++ b/src/CaptainHook.Api/Controllers/SubscribersController.cs
@@ -44,7 +44,7 @@ namespace CaptainHook.Api.Controllers
         /// <response code="500">An error occurred while processing the request</response>
         /// <response code="401">Request not authorized</response>
         [HttpGet]
-        [ProducesResponseType(typeof(IDictionary<string, SubscriberConfiguration>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/src/CaptainHook.Api/Controllers/SubscribersController.cs
+++ b/src/CaptainHook.Api/Controllers/SubscribersController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using CaptainHook.Api.Constants;
 using CaptainHook.Application.Infrastructure.DirectorService.Remoting;
@@ -43,7 +44,7 @@ namespace CaptainHook.Api.Controllers
         /// <response code="500">An error occurred while processing the request</response>
         /// <response code="401">Request not authorized</response>
         [HttpGet]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IDictionary<string, SubscriberConfiguration>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/src/CaptainHook.Api/Startup.cs
+++ b/src/CaptainHook.Api/Startup.cs
@@ -91,16 +91,19 @@ namespace CaptainHook.Api
                 _configuration.GetSection("ServiceConfigurationOptions").Bind(serviceConfiguration);
 
                 services.AddControllers(options =>
-                {
-                    var policy = ScopePolicy.Create(serviceConfiguration.RequiredScopes?.ToArray() ?? new string[0]);
+                    {
+                        var policy =
+                            ScopePolicy.Create(serviceConfiguration.RequiredScopes?.ToArray() ?? new string[0]);
 
-                    var filter = EnvironmentHelper.IsInFabric ?
-                        (IFilterMetadata)new AuthorizeFilter(policy) :
-                        new AllowAnonymousFilter();
+                        var filter = EnvironmentHelper.IsInFabric
+                            ? (IFilterMetadata) new AuthorizeFilter(policy)
+                            : new AllowAnonymousFilter();
 
-                    options.Filters.Add(filter);
-
-                }).AddNewtonsoftJson();
+                        options.Filters.Add(filter);
+                    })
+                    .AddNewtonsoftJson()
+                    .ConfigureApiBehaviorOptions(options =>
+                        options.SuppressMapClientErrors = true);
 
                 services.AddApiVersioning(options => options.AssumeDefaultVersionWhenUnspecified = true);
                 services.AddHealthChecks();

--- a/src/CaptainHook.Application.Infrastructure/DirectorService/Remoting/IDirectorServiceRemoting.cs
+++ b/src/CaptainHook.Application.Infrastructure/DirectorService/Remoting/IDirectorServiceRemoting.cs
@@ -17,5 +17,6 @@ namespace CaptainHook.Application.Infrastructure.DirectorService.Remoting
         Task<RequestReloadConfigurationResult> RequestReloadConfigurationAsync();
         Task<IDictionary<string, SubscriberConfiguration>> GetAllSubscribersAsync();
         Task<ReaderChangeResult> ApplyReaderChange(ReaderChangeBase readerChange);
+        Task<ReloadConfigurationStatus> GetReloadConfigurationStatusAsync();
     }
 }

--- a/src/CaptainHook.Application.Infrastructure/DirectorService/Remoting/ReloadConfigurationStatus.cs
+++ b/src/CaptainHook.Application.Infrastructure/DirectorService/Remoting/ReloadConfigurationStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace CaptainHook.Application.Infrastructure.DirectorService.Remoting
+{
+    public enum ReloadConfigurationStatus
+    {
+        Loaded = 0,
+        InProgress
+    }
+}

--- a/src/CaptainHook.DirectorService/DirectorService.cs
+++ b/src/CaptainHook.DirectorService/DirectorService.cs
@@ -139,6 +139,13 @@ namespace CaptainHook.DirectorService
             return Task.FromResult(RequestReloadConfigurationResult.ReloadInProgress);
         }
 
+        public Task<ReloadConfigurationStatus> GetReloadConfigurationStatusAsync()
+        {
+            var status = _refreshInProgress ? ReloadConfigurationStatus.InProgress : ReloadConfigurationStatus.Loaded;
+
+            return Task.FromResult(status);
+        }
+
         public Task<IDictionary<string, SubscriberConfiguration>> GetAllSubscribersAsync()
         {
             return Task.FromResult(_subscriberConfigurations);

--- a/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
@@ -19,7 +19,7 @@ namespace CaptainHook.Api.Tests
         [Fact(Skip = "Skipped: a successful RefreshConfig makes the other tests fail until refresh is complete."), IsIntegration]
         public async Task RefreshConfig_WhenAuthenticated_Returns202Accepted()
         {
-            var result = await AuthenticatedClient.ReloadWithHttpMessagesAsync();
+            var result = await AuthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();
 
             result.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         }
@@ -27,7 +27,7 @@ namespace CaptainHook.Api.Tests
         [Fact, IsIntegration]
         public async Task RefreshConfig_WhenUnauthenticated_Returns401Unauthorized()
         {
-            var result = await UnauthenticatedClient.ReloadWithHttpMessagesAsync();
+            var result = await UnauthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();
 
             result.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
         }

--- a/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
@@ -17,7 +17,8 @@ namespace CaptainHook.Api.Tests
         {
         }
 
-        [Fact, IsIntegration]
+
+        [Fact(Skip = "A successful RefreshConfig makes the other tests fail until refresh is complete"), IsIntegration]
         public async Task RefreshConfig_WhenAuthenticated_Returns202Accepted()
         {
             var result = await AuthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();

--- a/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
@@ -18,7 +18,7 @@ namespace CaptainHook.Api.Tests
         }
 
 
-        [Fact(Skip = "A successful RefreshConfig makes the other tests fail until refresh is complete"), IsIntegration]
+        [Fact(Skip = "Skipped: a successful RefreshConfig makes the other tests fail until refresh is complete."), IsIntegration]
         public async Task RefreshConfig_WhenAuthenticated_Returns202Accepted()
         {
             var result = await AuthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();

--- a/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Api/RefreshConfigControllerTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using CaptainHook.Api.Client;
+﻿using System.Threading.Tasks;
 using CaptainHook.Api.Tests.Api;
 using CaptainHook.Api.Tests.Config;
 using Eshopworld.Tests.Core;
@@ -21,7 +19,7 @@ namespace CaptainHook.Api.Tests
         [Fact(Skip = "Skipped: a successful RefreshConfig makes the other tests fail until refresh is complete."), IsIntegration]
         public async Task RefreshConfig_WhenAuthenticated_Returns202Accepted()
         {
-            var result = await AuthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();
+            var result = await AuthenticatedClient.ReloadWithHttpMessagesAsync();
 
             result.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         }
@@ -29,7 +27,7 @@ namespace CaptainHook.Api.Tests
         [Fact, IsIntegration]
         public async Task RefreshConfig_WhenUnauthenticated_Returns401Unauthorized()
         {
-            var result = await UnauthenticatedClient.ReloadConfigurationWithHttpMessagesAsync();
+            var result = await UnauthenticatedClient.ReloadWithHttpMessagesAsync();
 
             result.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
         }


### PR DESCRIPTION
### What
We have extended the APi with api/config/status endpoint which returns 200 if config has been loaded and 202 if the load is in progress. The choice of status codes was arbitrary and discussed within the team (also documented in UI).

### Why
The status code is going to be used in integration tests to wait for the reload to finish. It has been decided by the team that it is a better decision to extend the API than address the problem in another way.