### PR TITLE
Fix ch api test project load error

### DIFF
--- a/src/Tests/CaptainHook.Api.Tests/CaptainHook.Api.Tests.csproj
+++ b/src/Tests/CaptainHook.Api.Tests/CaptainHook.Api.Tests.csproj
@@ -18,7 +18,6 @@
 		<CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.json">
-		<DependentUpon>appsettings.json</DependentUpon>
 		<CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.PREP.json">


### PR DESCRIPTION
The `CaptainHook.Api.Tests` project fails to load due to a "File cannot depend on itself" error. Didn't get this error until I restarted VS yesterday.