### PR TITLE
Event reader service tests fix

### DIFF
--- a/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderTests.cs
@@ -120,7 +120,8 @@ namespace CaptainHook.Tests.Services.Reliable
             await service.InvokeRunAsync(cancellationTokenSource.Token);
 
             //Assert that the dictionary contains 1 processing message and associated handle            
-            Assert.Equal(expectedHandleCount, service._inflightMessages.Count);
+            //Assert.Equal(expectedHandleCount, service._inflightMessages.Count);
+            expectedHandleCount.Should().Be(service._inflightMessages.Count);
         }
 
         [Fact]
@@ -158,7 +159,7 @@ namespace CaptainHook.Tests.Services.Reliable
             await service.InvokeRunAsync(cancellationTokenSource.Token);
 
             //Assert can cancel the service from running
-            Assert.True(cancellationTokenSource.IsCancellationRequested);
+            cancellationTokenSource.IsCancellationRequested.Should().BeTrue();
         }
 
         [Theory]
@@ -217,7 +218,7 @@ namespace CaptainHook.Tests.Services.Reliable
             await service.InvokeOnOpenAsync(ReplicaOpenMode.New, cancellationTokenSource.Token);
             await service.InvokeRunAsync(cancellationTokenSource.Token);
 
-            Assert.Equal(expectedHandlerId, service.HandlerCount);
+            expectedHandlerId.Should().Be(service.HandlerCount);
         }
 
         [Theory]
@@ -293,8 +294,8 @@ namespace CaptainHook.Tests.Services.Reliable
 
         [Theory]
         [IsUnit]
-        [InlineData("test.type", "test.type-1", 1)]
-        [InlineData("test.type", "test.type-2", 5)]
+        [InlineData("test.type", "test.type-subA-1", 1)]
+        [InlineData("test.type", "test.type-subA-2", 5)]
         public async Task InitSubscriberDataIsPassedToHandlers(string eventName, string handlerName, int messageCount)
         {
             var actor = CreateMockEventHandlerActor(new ActorId(handlerName));
@@ -348,7 +349,9 @@ namespace CaptainHook.Tests.Services.Reliable
             await service.InvokeOnOpenAsync(ReplicaOpenMode.New, cancellationTokenSource.Token);
             await service.InvokeRunAsync(cancellationTokenSource.Token);
 
-            actor.MessageDataInstances.Select(m => m.SubscriberConfig).Should().AllBeEquivalentTo(subscriberConfiguration);
+            var subscriberConfigurations = actor.MessageDataInstances.Select(m => m.SubscriberConfig).ToList();
+            subscriberConfigurations.Should().HaveCountGreaterOrEqualTo(1);
+            subscriberConfigurations.Should().AllBeEquivalentTo(subscriberConfiguration);
         }
 
         /// <summary>


### PR DESCRIPTION
EventReaderServiceTests contains a lot of code duplicated in every method.
Also one of the tests (`InitSubscriberDataIsPassedToHandlers`) was false positive because of invalid assertion logic.

Such assertion: 
```
collection.Should().AllBeEquivalentTo(new SubscriberConfiguration { EventType = eventName, SubscriberName = "subA" });
```
won't fail if `collection` is empty. It might seem counter-intuitive at the first glance but it's logical. 
So if we'd like to perform `AllBeEquivalentTo` assertion we should first check if collection is not empty.