### PR TITLE
#80115 - provide endpoint selector identifier in the uri, use * as default

### DIFF
--- a/src/CaptainHook.Api/Controllers/EventsController.cs
+++ b/src/CaptainHook.Api/Controllers/EventsController.cs
@@ -40,9 +40,10 @@ namespace CaptainHook.Api.Controllers
         /// </summary>
         /// <param name="eventName">Event name</param>
         /// <param name="subscriberName">Subscriber name</param>
+        /// /// <param name="selector">Endpoint selector, use * (asterisk) for the default endpoint</param>
         /// <param name="dto">Webhook configuration</param>
         /// <returns></returns>
-        [HttpPut("{eventName}/subscriber/{subscriberName}/webhooks/endpoint/")]
+        [HttpPut("{eventName}/subscriber/{subscriberName}/webhooks/endpoint/{selector}")]
         [ProducesResponseType(typeof(EndpointDto), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(EndpointDto), StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ValidationError), StatusCodes.Status400BadRequest)]
@@ -50,9 +51,9 @@ namespace CaptainHook.Api.Controllers
         [ProducesResponseType(typeof(ErrorBase), StatusCodes.Status403Forbidden)]
         [ProducesResponseType(typeof(DirectorServiceIsBusyError), StatusCodes.Status409Conflict)]
         [ProducesResponseType(typeof(ErrorBase), StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> PutWebhook([FromRoute] string eventName, [FromRoute] string subscriberName, [FromBody] EndpointDto dto)
+        public async Task<IActionResult> PutWebhook([FromRoute] string eventName, [FromRoute] string subscriberName, [FromRoute] string selector, [FromBody] EndpointDto dto)
         {
-            var request = new UpsertWebhookRequest(eventName, subscriberName, dto);
+            var request = new UpsertWebhookRequest(eventName, subscriberName, selector, dto);
             var result = await _mediator.Send(request);
 
             return result.Match<IActionResult>(
@@ -64,33 +65,16 @@ namespace CaptainHook.Api.Controllers
                      CannotSaveEntityError cannotSaveEntityError => UnprocessableEntity(cannotSaveEntityError),
                      _ => StatusCode(StatusCodes.Status500InternalServerError, error) 
                  },
-                 endpointDto => Created($"/{eventName}/subscriber/{subscriberName}/webhooks/endpoint/", endpointDto)
+                 endpointDto => Created($"/{eventName}/subscriber/{subscriberName}/webhooks/endpoint/{selector}", endpointDto)
              );
         }
-
-        /// <summary>
-        /// Delete the default webhook for the provided event and subscriber
-        /// </summary>
-        /// <param name="eventName">Event name</param>
-        /// <param name="subscriberName">Subscriber name</param>
-        /// <returns></returns>
-        [HttpDelete("{eventName}/subscriber/{subscriberName}/webhooks/endpoint")]
-        [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(typeof(ValidationError), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(ErrorBase), StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(typeof(ErrorBase), StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(typeof(DirectorServiceIsBusyError), StatusCodes.Status409Conflict)]
-        [ProducesResponseType(typeof(ErrorBase), StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult>
-            DeleteDefaultWebhook([FromRoute] string eventName, [FromRoute] string subscriberName) =>
-            await DeleteWebhook(eventName, subscriberName, null);
 
         /// <summary>
         /// Delete a webhook for the provided event, subscriber and selector
         /// </summary>
         /// <param name="eventName">Event name</param>
         /// <param name="subscriberName">Subscriber name</param>
-        /// <param name="selector">Endpoint selector</param>
+        /// <param name="selector">Endpoint selector, use * (asterisk) for the default endpoint</param>
         /// <returns></returns>
         [HttpDelete("{eventName}/subscriber/{subscriberName}/webhooks/endpoint/{selector}")]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
@@ -130,7 +130,7 @@ namespace CaptainHook.Application.Handlers.Subscribers
         {
             var authDto = request.Endpoint.Authentication;
             var authenticationEntity = new AuthenticationEntity(authDto.ClientId, authDto.ClientSecretKeyName, authDto.Uri, authDto.Type, authDto.Scopes.ToArray());
-            var endpoint = new EndpointEntity(request.Endpoint.Uri, authenticationEntity, request.Endpoint.HttpVerb, request.Endpoint.Selector, parent);
+            var endpoint = new EndpointEntity(request.Endpoint.Uri, authenticationEntity, request.Endpoint.HttpVerb, request.Selector, parent);
 
             return endpoint;
         }

--- a/src/CaptainHook.Application/Requests/Subscribers/UpsertWebhookRequest.cs
+++ b/src/CaptainHook.Application/Requests/Subscribers/UpsertWebhookRequest.cs
@@ -9,11 +9,13 @@ namespace CaptainHook.Application.Requests.Subscribers
         public string EventName { get; }
         public string SubscriberName { get; }
         public EndpointDto Endpoint { get; }
+        public string Selector { get; set; }
 
-        public UpsertWebhookRequest(string eventName, string subscriberName, EndpointDto dto)
+        public UpsertWebhookRequest(string eventName, string subscriberName, string selector, EndpointDto dto)
         {
             EventName = eventName;
             SubscriberName = subscriberName;
+            Selector = selector;
             Endpoint = dto;
         }
     }

--- a/src/CaptainHook.Application/Validators/DeleteWebhookRequestValidator.cs
+++ b/src/CaptainHook.Application/Validators/DeleteWebhookRequestValidator.cs
@@ -11,7 +11,7 @@ namespace CaptainHook.Application.Validators
 
             RuleFor(x => x.EventName).NotEmpty();
             RuleFor(x => x.SubscriberName).NotEmpty();
-            RuleFor(x => x.Selector).NotEmpty().When(x => x.Selector != null);
+            RuleFor(x => x.Selector).NotEmpty();
         }
     }
 }

--- a/src/CaptainHook.Application/Validators/Dtos/UpsertEndpointDtoValidator.cs
+++ b/src/CaptainHook.Application/Validators/Dtos/UpsertEndpointDtoValidator.cs
@@ -1,0 +1,22 @@
+﻿using CaptainHook.Contract;
+using FluentValidation;
+
+namespace CaptainHook.Application.Validators.Dtos
+{
+    public class UpsertEndpointDtoValidator : AbstractValidator<EndpointDto>
+    {
+        private const string SelectorValidationMessage = "Selector has to match the selector identifier or be empty";
+
+        public UpsertEndpointDtoValidator(string upsertSelector)
+        {
+            CascadeMode = CascadeMode.StopOnFirstFailure;
+
+            Include(new EndpointDtoValidator());
+            RuleFor(x => x.Selector)
+                .Empty().When(x => string.IsNullOrWhiteSpace(x.Selector))
+                .WithMessage(SelectorValidationMessage)
+                .Equal(upsertSelector).When(x => !string.IsNullOrWhiteSpace(x.Selector))
+                .WithMessage(SelectorValidationMessage);
+        }
+    }
+}

--- a/src/CaptainHook.Application/Validators/Dtos/UpsertSubscriberEndpointDtoValidator.cs
+++ b/src/CaptainHook.Application/Validators/Dtos/UpsertSubscriberEndpointDtoValidator.cs
@@ -1,0 +1,16 @@
+﻿using CaptainHook.Contract;
+using FluentValidation;
+
+namespace CaptainHook.Application.Validators.Dtos
+{
+    public class UpsertSubscriberEndpointDtoValidator : AbstractValidator<EndpointDto>
+    {
+        public UpsertSubscriberEndpointDtoValidator()
+        {
+            CascadeMode = CascadeMode.StopOnFirstFailure;
+
+            Include(new EndpointDtoValidator());
+            RuleFor(x => x.Selector).NotEmpty();
+        }
+    }
+}

--- a/src/CaptainHook.Application/Validators/UpsertWebhookRequestValidator.cs
+++ b/src/CaptainHook.Application/Validators/UpsertWebhookRequestValidator.cs
@@ -12,8 +12,9 @@ namespace CaptainHook.Application.Validators
 
             RuleFor(x => x.EventName).NotEmpty();
             RuleFor(x => x.SubscriberName).NotEmpty();
+            RuleFor(x => x.Selector).NotEmpty();
             RuleFor(x => x.Endpoint).NotNull()
-                .SetValidator(new EndpointDtoValidator());
+                .SetValidator(request => new UpsertEndpointDtoValidator(request.Selector));
         }
     }
 }

--- a/src/CaptainHook.Domain/Entities/EndpointEntity.cs
+++ b/src/CaptainHook.Domain/Entities/EndpointEntity.cs
@@ -5,6 +5,8 @@
     /// </summary>
     public class EndpointEntity
     {
+        public const string DefaultEndpointSelector = "*";
+
         /// <summary>
         /// Parent subscriber model
         /// </summary>
@@ -29,8 +31,6 @@
         /// Endpoint selector
         /// </summary>
         public string Selector { get; }
-
-        
 
         public EndpointEntity(string uri, AuthenticationEntity authentication, string httpVerb, string selector, 
             SubscriberEntity subscriber = null)

--- a/src/CaptainHook.Domain/Entities/WebhooksEntityValidator.cs
+++ b/src/CaptainHook.Domain/Entities/WebhooksEntityValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 
@@ -24,12 +25,12 @@ namespace CaptainHook.Domain.Entities
 
         private bool ContainOnlyDefaultEndpointIfNoSelectionRule(WebhooksEntity webhooks)
         {
-            return ! string.IsNullOrEmpty(webhooks.SelectionRule) || ContainOnlySingleWebhookWithNoSelector(webhooks.Endpoints);
+            return ! string.IsNullOrEmpty(webhooks.SelectionRule) || ContainOnlySingleWebhookWithDefaultSelector(webhooks.Endpoints);
         }
 
-        private static bool ContainOnlySingleWebhookWithNoSelector(IEnumerable<EndpointEntity> endpoints)
+        private static bool ContainOnlySingleWebhookWithDefaultSelector(IEnumerable<EndpointEntity> endpoints)
         {
-            return endpoints?.Count(e => string.IsNullOrEmpty(e.Selector)) == 1
+            return endpoints?.Count(e => string.Equals(e.Selector, EndpointEntity.DefaultEndpointSelector, StringComparison.OrdinalIgnoreCase)) == 1
                 && endpoints?.Count() == 1;
         }
     }

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
@@ -28,7 +28,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         private readonly Mock<IDirectorServiceProxy> _directorServiceMock = new Mock<IDirectorServiceProxy>();
 
         private readonly UpsertWebhookRequest _defaultUpsertRequest =
-            new UpsertWebhookRequest("event", "subscriber", new EndpointDtoBuilder().With(x => x.Selector, null).Create());
+            new UpsertWebhookRequest("event", "subscriber", "*", new EndpointDtoBuilder().Create());
 
         private static readonly SubscriberBuilder DefaultSubscriberBuilder = new SubscriberBuilder().WithEvent("event")
             .WithName("subscriber")

--- a/src/Tests/CaptainHook.Application.Tests/RequestValidators/DeleteWebhookRequestValidatorTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/RequestValidators/DeleteWebhookRequestValidatorTests.cs
@@ -13,7 +13,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
 
         [Theory, IsUnit]
         [InlineData("selector")]
-        [InlineData(null)]
+        [InlineData("*")]
         public void When_RequestIsValid_Then_NoFailuresReturned(string validSelector)
         {
             var request = new DeleteWebhookRequest("event", "subscriber", validSelector);
@@ -24,8 +24,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         }
 
         [Theory, IsUnit]
-        [InlineData("")]
-        [InlineData("   ")]
+        [ClassData(typeof(EmptyStrings))]
         public void When_SelectorIsINvalid_Then_ValidationFails(string selector)
         {
             var request = new DeleteWebhookRequest("event", "subscriber", selector);

--- a/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertWebhookRequestValidatorTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertWebhookRequestValidatorTests.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using CaptainHook.Application.Requests.Subscribers;
+﻿using CaptainHook.Application.Requests.Subscribers;
 using CaptainHook.Application.Validators;
-using CaptainHook.Contract;
 using CaptainHook.TestsInfrastructure.Builders;
 using CaptainHook.TestsInfrastructure.TestsData;
 using Eshopworld.Tests.Core;
@@ -18,7 +16,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         [Fact, IsUnit]
         public void When_RequestIsValid_Then_NoFailuresReturned()
         {
-            var request = new UpsertWebhookRequest("event", "subscriber", new EndpointDtoBuilder().Create());
+            var request = new UpsertWebhookRequest("event", "subscriber", "*", new EndpointDtoBuilder().Create());
 
             var result = _validator.TestValidate(request);
 
@@ -35,7 +33,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         public void When_HttpVerbIsAValidHTTPVerb_Then_NoFailuresReturned(string httpVerb)
         {
             var dto = new EndpointDtoBuilder().With(x => x.HttpVerb, httpVerb).Create();
-            var request = new UpsertWebhookRequest("event", "subscriber", dto);
+            var request = new UpsertWebhookRequest("event", "subscriber", "*", dto);
 
             var result = _validator.TestValidate(request);
 
@@ -46,7 +44,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         [ClassData(typeof(EmptyStrings))]
         public void When_EventIsEmpty_Then_ValidationFails(string invalidString)
         {
-            var request = new UpsertWebhookRequest(invalidString, "subscriber", new EndpointDtoBuilder().Create());
+            var request = new UpsertWebhookRequest(invalidString, "subscriber", "*", new EndpointDtoBuilder().Create());
 
             var result = _validator.TestValidate(request);
 
@@ -57,7 +55,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         [ClassData(typeof(EmptyStrings))]
         public void When_SubscriberIsEmpty_Then_ValidationFails(string invalidString)
         {
-            var request = new UpsertWebhookRequest("event", invalidString, new EndpointDtoBuilder().Create());
+            var request = new UpsertWebhookRequest("event", invalidString, "*", new EndpointDtoBuilder().Create());
 
             var result = _validator.TestValidate(request);
 
@@ -69,7 +67,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         public void When_UriIsEmpty_Then_ValidationFails(string uri)
         {
             var dto = new EndpointDtoBuilder().With(x => x.Uri, uri).Create();
-            var request = new UpsertWebhookRequest("event", "subscriber", dto);
+            var request = new UpsertWebhookRequest("event", "subscriber", "*", dto);
 
             var result = _validator.TestValidate(request);
 
@@ -81,7 +79,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         public void When_UriIsNotValid_Then_ValidationFails(string uri)
         {
             var dto = new EndpointDtoBuilder().With(x => x.Uri, uri).Create();
-            var request = new UpsertWebhookRequest("event", "subscriber", dto);
+            var request = new UpsertWebhookRequest("event", "subscriber", "*", dto);
 
             var result = _validator.TestValidate(request);
 
@@ -93,7 +91,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         public void When_HttpVerbIsEmpty_Then_ValidationFails(string httpVerb)
         {
             var dto = new EndpointDtoBuilder().With(x => x.HttpVerb, httpVerb).Create();
-            var request = new UpsertWebhookRequest("event", "subscriber", dto);
+            var request = new UpsertWebhookRequest("event", "subscriber", "*", dto);
 
             var result = _validator.TestValidate(request);
 
@@ -105,7 +103,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
         public void When_HttpVerbIsNotValidHTTPVerb_Then_ValidationFails(string httpVerb)
         {
             var dto = new EndpointDtoBuilder().With(x => x.HttpVerb, httpVerb).Create();
-            var request = new UpsertWebhookRequest("event", "subscriber", dto);
+            var request = new UpsertWebhookRequest("event", "subscriber", "*", dto);
 
             var result = _validator.TestValidate(request);
 
@@ -118,7 +116,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
             var dto = new EndpointDtoBuilder()
                 .With(x => x.Uri, "https://blah-{selector}.eshopworld.com/webhook/")
                 .Create();
-            var request = new UpsertWebhookRequest("event", "subscriber", dto);
+            var request = new UpsertWebhookRequest("event", "subscriber", "*", dto);
 
             var result = _validator.TestValidate(request);
 

--- a/src/Tests/CaptainHook.Application.Tests/Validators/Dtos/UpsertEndpointDtoValidatorTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Validators/Dtos/UpsertEndpointDtoValidatorTests.cs
@@ -1,0 +1,58 @@
+﻿using CaptainHook.Application.Validators.Dtos;
+using CaptainHook.Contract;
+using CaptainHook.TestsInfrastructure.TestsData;
+using Eshopworld.Tests.Core;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace CaptainHook.Application.Tests.Validators.Dtos
+{
+    public class UpsertEndpointDtoValidatorTests
+    {
+        private readonly UpsertEndpointDtoValidator _defaultValidator = new UpsertEndpointDtoValidator("*");
+
+        [Theory, IsUnit]
+        [ClassData(typeof(EmptyStrings))]
+        public void Validate_NoSelectorProvided_SuccessValidation(string selectorString)
+        {
+            // Arrange
+            var endpoint = new EndpointDto { Selector = selectorString };
+
+            // Act
+            var result = _defaultValidator.TestValidate(endpoint);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Selector);
+        }
+
+        [Fact, IsUnit]
+        public void Validate_DifferentSelectorProvided_FailedValidation()
+        {
+            // Arrange
+            var endpoint = new EndpointDto { Selector = "abc" };
+
+            // Act
+            var result = _defaultValidator.TestValidate(endpoint);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Selector)
+                .WithErrorMessage("Selector has to match the selector identifier or be empty");
+        }
+
+        [Theory, IsUnit]
+        [InlineData("*")]
+        [InlineData("abc")]
+        public void Validate_SameSelectorProvided_SuccessValidation(string selector)
+        {
+            // Arrange
+            var validator = new UpsertEndpointDtoValidator(selector);
+            var endpoint = new EndpointDto { Selector = selector };
+
+            // Act
+            var result = validator.TestValidate(endpoint);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Selector);
+        }
+    }
+}

--- a/src/Tests/CaptainHook.Application.Tests/Validators/Dtos/UpsertSubscriberEndpointDtoValidatorTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Validators/Dtos/UpsertSubscriberEndpointDtoValidatorTests.cs
@@ -1,0 +1,43 @@
+﻿using CaptainHook.Application.Validators.Dtos;
+using CaptainHook.Contract;
+using CaptainHook.TestsInfrastructure.TestsData;
+using Eshopworld.Tests.Core;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace CaptainHook.Application.Tests.Validators.Dtos
+{
+    public class UpsertSubscriberEndpointDtoValidatorTests
+    {
+        private readonly UpsertSubscriberEndpointDtoValidator _defaultValidator = new UpsertSubscriberEndpointDtoValidator();
+
+        [Theory, IsUnit]
+        [ClassData(typeof(EmptyStrings))]
+        public void Validate_NoSelectorProvided_FailedValidation(string selectorString)
+        {
+            // Arrange
+            var endpoint = new EndpointDto { Selector = selectorString };
+
+            // Act
+            var result = _defaultValidator.TestValidate(endpoint);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Selector);
+        }
+
+        [Theory, IsUnit]
+        [InlineData("abc")]
+        [InlineData("*")]
+        public void Validate_SelectorProvided_SuccessValidation(string selectorString)
+        {
+            // Arrange
+            var endpoint = new EndpointDto { Selector = selectorString };
+
+            // Act
+            var result = _defaultValidator.TestValidate(endpoint);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Selector);
+        }
+    }
+}

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/EndpointDtoBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/EndpointDtoBuilder.cs
@@ -7,7 +7,7 @@ namespace CaptainHook.TestsInfrastructure.Builders
         public EndpointDtoBuilder()
         {
             With(e => e.Uri, "https://blah.blah.eshopworld.com/webhook/");
-            With(e => e.Selector, "selector");
+            With(e => e.Selector, "*");
             With(e => e.HttpVerb, "POST");
             With(e => e.Authentication, new AuthenticationDtoBuilder().Create());
         }


### PR DESCRIPTION
This PR focuses on two main aspects:

1. Specify endpoint selector in the uri
2. Use * as the default selector (instead of null previously)

### What

The API endpoints are not duplicated now as both PUT and DELETE can handle selectors:
![image](https://user-images.githubusercontent.com/60343978/91160044-37f77280-e6c9-11ea-86b6-bdfc0898213a.png)

The information on * is also provided is Swagger UI for visual support:
![image](https://user-images.githubusercontent.com/60343978/91160089-45146180-e6c9-11ea-8cd0-9107b0dfabf1.png)
