### PR TITLE
#82366 DTO to Entity mapper service & tests

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/CaptainHook.Application.Infrastructure.csproj
+++ b/src/CaptainHook.Application.Infrastructure/CaptainHook.Application.Infrastructure.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CaptainHook.Common\CaptainHook.Common.csproj" />
+    <ProjectReference Include="..\CaptainHook.Contract\CaptainHook.Contract.csproj" />
     <ProjectReference Include="..\CaptainHook.Domain\CaptainHook.Domain.csproj" />
   </ItemGroup>
 

--- a/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
@@ -1,0 +1,45 @@
+﻿using CaptainHook.Contract;
+using CaptainHook.Domain.Entities;
+using System.Linq;
+
+namespace CaptainHook.Application.Infrastructure.Mappers
+{
+    public class DtoToEntityMapper : IDtoToEntityMapper
+    {
+        public WebhooksEntity MapWebooks(WebhooksDto webhooksDto)
+        {
+            return new WebhooksEntity(
+                webhooksDto.SelectionRule,
+                webhooksDto.Endpoints?.Select(MapEndpoint) ?? Enumerable.Empty<EndpointEntity>(),
+                MapUriTransform(webhooksDto.UriTransform));
+        }
+
+        public EndpointEntity MapEndpoint(EndpointDto endpointDto)
+        {
+            var authenticationEntity = MapAuthentication(endpointDto.Authentication);
+            var endpoint = new EndpointEntity(endpointDto.Uri, authenticationEntity, endpointDto.HttpVerb, endpointDto.Selector);
+
+            return endpoint;
+        }
+
+        public UriTransformEntity MapUriTransform(UriTransformDto uriTransformDto)
+        {
+            if (uriTransformDto?.Replace == null)
+            {
+                return null;
+            }
+
+            return new UriTransformEntity(uriTransformDto.Replace);
+        }
+
+        public AuthenticationEntity MapAuthentication(AuthenticationDto authenticationDto)
+        {
+            return authenticationDto switch
+            {
+                BasicAuthenticationDto dto => new BasicAuthenticationEntity(dto.Username, dto.Password),
+                OidcAuthenticationDto dto => new OidcAuthenticationEntity(dto.ClientId, dto.ClientSecretKeyName, dto.Uri, dto.Scopes?.ToArray()),
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/CaptainHook.Application.Infrastructure/Mappers/IDtoToEntityMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/IDtoToEntityMapper.cs
@@ -1,0 +1,36 @@
+﻿using CaptainHook.Contract;
+using CaptainHook.Domain.Entities;
+
+namespace CaptainHook.Application.Infrastructure.Mappers
+{
+    public interface IDtoToEntityMapper
+    {
+        /// <summary>
+        /// Maps a Webooks DTO to a Webooks entity
+        /// </summary>
+        /// <param name="webhooksDto">A Webooks DTO</param>
+        /// <returns>A Webooks entity</returns>
+        WebhooksEntity MapWebooks(WebhooksDto webhooksDto);
+
+        /// <summary>
+        /// Maps an Endpoint DTO to an Endpoint entity
+        /// </summary>
+        /// <param name="endpointDto">An Endpoint DTO</param>
+        /// <returns>An Endpoint entity</returns>
+        EndpointEntity MapEndpoint(EndpointDto endpointDto);
+
+        /// <summary>
+        /// Maps a URITransfrom DTO to a URITransform entity
+        /// </summary>
+        /// <param name="uriTransformDto">A URI Transfor DTO</param>
+        /// <returns>A URI Transfor entity</returns>
+        UriTransformEntity MapUriTransform(UriTransformDto uriTransformDto);
+
+        /// <summary>
+        /// Maps an Authentication DTO to an Authentication entity
+        /// </summary>
+        /// <param name="authenticationDto">An Authentication DTO</param>
+        /// <returns>An Authentication entity</returns>
+        AuthenticationEntity MapAuthentication(AuthenticationDto authenticationDto);
+    }
+}

--- a/src/CaptainHook.Application/ApplicationModule.cs
+++ b/src/CaptainHook.Application/ApplicationModule.cs
@@ -19,6 +19,7 @@ namespace CaptainHook.Application
 
             builder.RegisterType<DirectorServiceProxy>().As<IDirectorServiceProxy>();
             builder.RegisterType<SubscriberEntityToConfigurationMapper>().As<ISubscriberEntityToConfigurationMapper>();
+            builder.RegisterType<DtoToEntityMapper>().As<IDtoToEntityMapper>();
 
             builder.RegisterMediatorInfrastructure(ThisAssembly, ThisAssembly);
         }

--- a/src/CaptainHook.Application/Handlers/Subscribers/DeleteWebhookRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/DeleteWebhookRequestHandler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Application.Infrastructure.DirectorService;
+using CaptainHook.Application.Infrastructure.Mappers;
 using CaptainHook.Application.Requests.Subscribers;
 using CaptainHook.Contract;
 using CaptainHook.Domain.Entities;
@@ -10,7 +11,6 @@ using CaptainHook.Domain.Errors;
 using CaptainHook.Domain.Repositories;
 using CaptainHook.Domain.Results;
 using CaptainHook.Domain.ValueObjects;
-using Eshopworld.Core;
 using Kusto.Cloud.Platform.Utils;
 using MediatR;
 using Polly;
@@ -25,22 +25,16 @@ namespace CaptainHook.Application.Handlers.Subscribers
         };
 
         private readonly ISubscriberRepository _subscriberRepository;
-
         private readonly IDirectorServiceProxy _directorService;
-
-        private readonly IBigBrother _bigBrother;
-
         private readonly TimeSpan[] _retrySleepDurations;
 
         public DeleteWebhookRequestHandler(
             ISubscriberRepository subscriberRepository,
             IDirectorServiceProxy directorService,
-            IBigBrother bigBrother,
             TimeSpan[] sleepDurations = null)
         {
             _subscriberRepository = subscriberRepository ?? throw new ArgumentNullException(nameof(subscriberRepository));
             _directorService = directorService ?? throw new ArgumentNullException(nameof(directorService));
-            _bigBrother = bigBrother ?? throw new ArgumentNullException(nameof(bigBrother));
             _retrySleepDurations = sleepDurations?.SafeFastNullIfEmpty() ?? DefaultRetrySleepDurations;
         }
 

--- a/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
+++ b/src/CaptainHook.Fabric/ApplicationParameters/Local.1Node.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/CaptainHook" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
-    <Parameter Name="KeyVault_Base_Uri" Value="https://esw-tooling-ci-we-ap.vault.azure.net/" />
+    <Parameter Name="KeyVault_Base_Uri" Value="https://esw-tooling-ci-we.vault.azure.net/" />
     <Parameter Name="AspNetCore_Environment" Value="Development" />
     <Parameter Name="CaptainHook.DirectorService_PartitionCount" Value="1" />
     <Parameter Name="CaptainHook.DirectorService_MinReplicaSetSize" Value="1" />

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/DeleteWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/DeleteWebhookRequestHandlerTests.cs
@@ -57,7 +57,6 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         private DeleteWebhookRequestHandler Handler => new DeleteWebhookRequestHandler(
             _repositoryMock.Object,
             _directorServiceMock.Object,
-            Mock.Of<IBigBrother>(),
             new[]
             {
                 TimeSpan.FromMilliseconds(10.0),

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
@@ -35,6 +35,9 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         public UpsertSubscriberRequestHandlerTests()
         {
             _handler = new UpsertSubscriberRequestHandler(_repositoryMock.Object, _directorServiceMock.Object, _dtoToEntityMapper.Object);
+
+            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
+                .Returns(new WebhooksEntity());
         }
 
         [Fact, IsUnit]
@@ -54,8 +57,6 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
-            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
-                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(request, CancellationToken.None);
 
@@ -83,8 +84,6 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
-            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
-                .Returns(new WebhooksEntity());
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
             var expectedResult = new OperationResult<UpsertResult<SubscriberDto>>(new UpsertResult<SubscriberDto>(_testRequest.Subscriber, UpsertType.Updated));
@@ -96,8 +95,6 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         {
             _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
                 .ReturnsAsync(new BusinessError("test error"));
-            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
-                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
@@ -112,8 +109,6 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new DirectorServiceIsBusyError());
-            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
-                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
@@ -128,8 +123,6 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new ReaderCreateError(new SubscriberEntity("subscriber")));
-            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
-                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
@@ -146,8 +139,6 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new BusinessError("test error"));
-            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
-                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
@@ -54,6 +54,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
+            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
+                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(request, CancellationToken.None);
 
@@ -81,7 +83,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
-
+            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
+                .Returns(new WebhooksEntity());
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
             var expectedResult = new OperationResult<UpsertResult<SubscriberDto>>(new UpsertResult<SubscriberDto>(_testRequest.Subscriber, UpsertType.Updated));
@@ -93,6 +96,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         {
             _repositoryMock.Setup(r => r.GetSubscriberAsync(It.Is<SubscriberId>(id => id.Equals(new SubscriberId("event", "subscriber")))))
                 .ReturnsAsync(new BusinessError("test error"));
+            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
+                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
@@ -107,6 +112,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new DirectorServiceIsBusyError());
+            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
+                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
@@ -121,6 +128,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new EntityNotFoundError("subscriber", "key"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new ReaderCreateError(new SubscriberEntity("subscriber")));
+            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
+                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 
@@ -137,6 +146,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new BusinessError("test error"));
+            _dtoToEntityMapper.Setup(r => r.MapWebooks(It.IsAny<WebhooksDto>()))
+                .Returns(new WebhooksEntity());
 
             var result = await _handler.Handle(_testRequest, CancellationToken.None);
 

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertSubscriberRequestHandlerTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Application.Handlers.Subscribers;
 using CaptainHook.Application.Infrastructure.DirectorService;
+using CaptainHook.Application.Infrastructure.Mappers;
 using CaptainHook.Application.Requests.Subscribers;
 using CaptainHook.Application.Results;
 using CaptainHook.Contract;
@@ -23,8 +24,9 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
     public class UpsertSubscriberRequestHandlerTests
     {
         private readonly Mock<ISubscriberRepository> _repositoryMock = new Mock<ISubscriberRepository>(MockBehavior.Strict);
-
         private readonly Mock<IDirectorServiceProxy> _directorServiceMock = new Mock<IDirectorServiceProxy>(MockBehavior.Strict);
+        private readonly Mock<IDtoToEntityMapper> _dtoToEntityMapper = new Mock<IDtoToEntityMapper>(MockBehavior.Strict);
+
 
         private readonly UpsertSubscriberRequest _testRequest = new UpsertSubscriberRequest("event", "subscriber", new SubscriberDtoBuilder().Create());
 
@@ -32,7 +34,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
 
         public UpsertSubscriberRequestHandlerTests()
         {
-            _handler = new UpsertSubscriberRequestHandler(_repositoryMock.Object, _directorServiceMock.Object);
+            _handler = new UpsertSubscriberRequestHandler(_repositoryMock.Object, _directorServiceMock.Object, _dtoToEntityMapper.Object);
         }
 
         [Fact, IsUnit]

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
@@ -28,8 +28,9 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         private readonly Mock<IDirectorServiceProxy> _directorServiceMock = new Mock<IDirectorServiceProxy>();
         private readonly Mock<IDtoToEntityMapper> _dtoToEntityMapper = new Mock<IDtoToEntityMapper>(MockBehavior.Strict);
 
-        private readonly UpsertWebhookRequest _defaultUpsertRequest =
-            new UpsertWebhookRequest("event", "subscriber", "*", new EndpointDtoBuilder().Create());
+        private static readonly EndpointDto _defaultEndpointDto = new EndpointDtoBuilder().Create();
+        private static readonly UpsertWebhookRequest _defaultUpsertRequest =
+            new UpsertWebhookRequest("event", "subscriber", "*", _defaultEndpointDto);
 
         private static readonly SubscriberBuilder DefaultSubscriberBuilder = new SubscriberBuilder().WithEvent("event")
             .WithName("subscriber")
@@ -63,6 +64,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(true);
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -70,6 +79,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.IsError.Should().BeFalse();
             _repositoryMock.VerifyAll();
             _directorServiceMock.VerifyAll();
+            _dtoToEntityMapper.VerifyAll();
         }
 
         [Fact, IsUnit]
@@ -82,6 +92,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -90,6 +108,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Data.Should().BeEquivalentTo(_defaultUpsertRequest.Endpoint);
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
         }
 
@@ -122,6 +141,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(new DirectorServiceIsBusyError());
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -130,6 +157,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Error.Should().BeOfType<DirectorServiceIsBusyError>();
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Never);
         }
 
@@ -142,6 +170,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(new ReaderCreateError(new SubscriberEntity("subscriber")));
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -149,6 +185,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.IsError.Should().BeTrue();
             result.Error.Should().BeOfType<ReaderCreateError>();
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Never);
         }
@@ -162,6 +199,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new BusinessError("test error"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(true);
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -169,6 +214,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.IsError.Should().BeTrue();
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
         }
 
@@ -181,6 +227,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new CannotUpdateEntityError("dummy-type", new Exception()));
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -188,6 +242,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Should().BeEquivalentTo(expectedResult);
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Exactly(3));
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(3));
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Exactly(3));
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(3));
         }
 
@@ -201,6 +256,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             _repositoryMock.SetupSequence(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new CannotUpdateEntityError("dummy-type", new Exception()))
                 .ReturnsAsync(() => DefaultSubscriberBuilder.Create());
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -208,6 +271,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Should().BeEquivalentTo(expectedResult);
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Exactly(2));
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(2));
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Exactly(2));
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(2));
         }
 
@@ -226,6 +290,14 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(() => DefaultSubscriberBuilder.Create());
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
 
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
@@ -235,6 +307,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Exactly(2));
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
         }
 

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Application.Handlers.Subscribers;
 using CaptainHook.Application.Infrastructure.DirectorService;
+using CaptainHook.Application.Infrastructure.Mappers;
 using CaptainHook.Application.Requests.Subscribers;
 using CaptainHook.Contract;
 using CaptainHook.Domain.Entities;
@@ -24,8 +25,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
     public class UpsertWebhookRequestHandlerTests
     {
         private readonly Mock<ISubscriberRepository> _repositoryMock = new Mock<ISubscriberRepository>();
-
         private readonly Mock<IDirectorServiceProxy> _directorServiceMock = new Mock<IDirectorServiceProxy>();
+        private readonly Mock<IDtoToEntityMapper> _dtoToEntityMapper = new Mock<IDtoToEntityMapper>(MockBehavior.Strict);
 
         private readonly UpsertWebhookRequest _defaultUpsertRequest =
             new UpsertWebhookRequest("event", "subscriber", "*", new EndpointDtoBuilder().Create());
@@ -45,8 +46,8 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
 
         private UpsertWebhookRequestHandler Handler => new UpsertWebhookRequestHandler(
             _repositoryMock.Object,
-            _directorServiceMock.Object, 
-            Mock.Of<IBigBrother>(),
+            _directorServiceMock.Object,
+            _dtoToEntityMapper.Object,
             new[]
             {
                 TimeSpan.FromMilliseconds(10.0),

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
@@ -13,7 +13,6 @@ using CaptainHook.Domain.Repositories;
 using CaptainHook.Domain.Results;
 using CaptainHook.Domain.ValueObjects;
 using CaptainHook.TestsInfrastructure.Builders;
-using Eshopworld.Core;
 using Eshopworld.Tests.Core;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -55,6 +54,18 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 TimeSpan.FromMilliseconds(10.0)
             });
 
+        public UpsertWebhookRequestHandlerTests()
+        {
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
+                    authentication: new OidcAuthenticationEntity(
+                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
+                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
+                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
+                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
+                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
+        }
+
         [Fact, IsUnit]
         public async Task When_SubscriberDoesNotExist_Then_NewOneWillBePassedToDirectorServiceAndStoredInRepository()
         {
@@ -64,15 +75,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(true);
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             using var scope = new AssertionScope();
@@ -92,15 +95,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             using var scope = new AssertionScope();
@@ -141,15 +136,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(new DirectorServiceIsBusyError());
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             using var scope = new AssertionScope();
@@ -170,15 +157,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new SubscriberEntity("subscriber"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(new ReaderCreateError(new SubscriberEntity("subscriber")));
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             using var scope = new AssertionScope();
@@ -199,15 +178,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(new BusinessError("test error"));
             _directorServiceMock.Setup(r => r.CreateReaderAsync(It.Is<SubscriberEntity>(rci => MatchReaderChangeInfo(rci, _defaultUpsertRequest))))
                 .ReturnsAsync(true);
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             using var scope = new AssertionScope();
@@ -227,15 +198,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new CannotUpdateEntityError("dummy-type", new Exception()));
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             var expectedResult = new OperationResult<EndpointDto>(new CannotUpdateEntityError("dummy-type", new Exception()));
@@ -256,15 +219,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             _repositoryMock.SetupSequence(r => r.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(new CannotUpdateEntityError("dummy-type", new Exception()))
                 .ReturnsAsync(() => DefaultSubscriberBuilder.Create());
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             var expectedResult = new OperationResult<EndpointDto>(_defaultUpsertRequest.Endpoint);
@@ -290,15 +245,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
                 .ReturnsAsync(true);
             _repositoryMock.Setup(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()))
                 .ReturnsAsync(() => DefaultSubscriberBuilder.Create());
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
-                .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
-                    authentication: new OidcAuthenticationEntity(
-                        clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
-                        clientSecretKeyName: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientSecretKeyName,
-                        uri: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Uri,
-                        scopes: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).Scopes.ToArray()
-                    ), _defaultEndpointDto.HttpVerb, _defaultEndpointDto.Selector));
-
+            
             var result = await Handler.Handle(_defaultUpsertRequest, CancellationToken.None);
 
             var expectedResult = new OperationResult<EndpointDto>(_defaultUpsertRequest.Endpoint);

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
@@ -1,0 +1,154 @@
+﻿using CaptainHook.Application.Infrastructure.Mappers;
+using CaptainHook.TestsInfrastructure.Builders;
+using FluentAssertions.Execution;
+using CaptainHook.Domain.Entities;
+using Eshopworld.Tests.Core;
+using Xunit;
+using FluentAssertions;
+using System.Collections.Generic;
+using CaptainHook.Contract;
+using System.Linq;
+
+namespace CaptainHook.Application.Tests.Infrastructure
+{
+    public class DtoToEntityMapperTests
+    {
+        [Fact]
+        [IsUnit]
+        public void MapAuthentication_WhenBasicAuthenticationDtoIsUsed_ThenIsMappedToBasicAuthenticationEntity()
+        {
+            var sut = new DtoToEntityMapper();
+
+            var dto = new BasicAuthenticationDtoBuilder()
+                .With(x => x.Username, "Username")
+                .With(x => x.Password, "Password")
+                .Create();
+
+            var entity = sut.MapAuthentication(dto);
+
+            using (new AssertionScope())
+            {
+                entity.Should().BeOfType(typeof(BasicAuthenticationEntity));
+                BasicAuthenticationEntity basicEntity = (BasicAuthenticationEntity)entity;
+                basicEntity.Username.Should().Be("Username");
+                basicEntity.Password.Should().Be("Password");
+            }
+        }
+
+        [Fact]
+        [IsUnit]
+        public void MapAuthentication_WhenOidcAuthenticationDtoIsUsed_ThenIsMappedToOidcAuthenticationEntity()
+        {
+            var sut = new DtoToEntityMapper();
+
+            var dto = new OidcAuthenticationDtoBuilder()
+                .With(x => x.ClientId, "ClientId")
+                .With(x => x.ClientSecretKeyName, "ClientSecretKeyName")
+                .With(x => x.Uri, "http://security.uri")
+                .With(x => x.Scopes, new List<string> { "scope" })
+                .Create();
+
+            var entity = sut.MapAuthentication(dto);
+
+            using (new AssertionScope())
+            {
+                entity.Should().BeOfType(typeof(OidcAuthenticationEntity));
+                OidcAuthenticationEntity oidcEntity = (OidcAuthenticationEntity)entity;
+                oidcEntity.ClientId.Should().Be("ClientId");
+                oidcEntity.ClientSecretKeyName.Should().Be("ClientSecretKeyName");
+                oidcEntity.Uri.Should().Be("http://security.uri");
+                oidcEntity.Scopes.Should().Contain(new List<string> { "scope" });
+            }
+        }
+
+        [Fact]
+        [IsUnit]
+        public void MapUriTransform_WhenValidUriTransformIsUsed_ThenIsMappedToUriTransformEntity()
+        {
+            var sut = new DtoToEntityMapper();
+
+            var dictionary = new Dictionary<string, string>
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2"
+            };
+            var dto = new UriTransformDtoBuilder()
+                .With(x => x.Replace, dictionary)
+                .Create();
+
+            var entity = sut.MapUriTransform(dto);
+
+            entity.Replace.Should().Contain(dictionary.ToList());
+        }
+
+        [Theory]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        [InlineData("GET")]
+        [IsUnit]
+        public void MapEndpoint_WhenValidEndpointIsUsed_ThenIsMappedToEndpointEntity(string httpVerb)
+        {
+            var sut = new DtoToEntityMapper();
+
+            var dto = new EndpointDtoBuilder()
+                .With(x => x.Selector, "Select")
+                .With(x => x.HttpVerb, httpVerb)
+                .With(x => x.Uri, "http://www.test.url")
+                .Create();
+
+
+            var entity = sut.MapEndpoint(dto);
+
+            using (new AssertionScope())
+            {
+                entity.Selector.Should().Be("Select");
+                entity.Uri.Should().Be("http://www.test.url");
+                entity.HttpVerb.Should().Be(httpVerb);
+            }
+        }
+
+        [Theory]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        [InlineData("GET")]
+        [IsUnit]
+        public void MapAEndpoint_WhenValidEndpointIsUsed_ThenIsMappedToEndpointEntity(string httpVerb)
+        {
+            var sut = new DtoToEntityMapper();
+
+            var endpointDto = new EndpointDtoBuilder()
+                .With(x => x.Selector, "Select")
+                .With(x => x.HttpVerb, httpVerb)
+                .With(x => x.Uri, "http://www.test.url")
+                .Create();
+
+            var dictionary = new Dictionary<string, string>
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2"
+            };
+            var uriTransformDto = new UriTransformDtoBuilder()
+                .With(x => x.Replace, dictionary)
+                .Create();
+
+            var dto = new WebhooksDtoBuilder()
+                .With(x => x.SelectionRule, "$.Select")
+                .With(x => x.Endpoints, new List<EndpointDto> { endpointDto })
+                .With(x => x.UriTransform, uriTransformDto)
+                .Create();
+
+            var entity = sut.MapWebooks(dto);
+
+            using (new AssertionScope())
+            {
+                entity.SelectionRule.Should().Be("$.Select");
+                entity.Endpoints.Should().HaveCount(1);
+                var endpointEntity = entity.Endpoints.First();
+                endpointEntity.Selector.Should().Be("Select");
+                endpointEntity.Uri.Should().Be("http://www.test.url");
+                endpointEntity.HttpVerb.Should().Be(httpVerb);
+                entity.UriTransform.Replace.Should().Contain(dictionary.ToList());
+            }
+        }
+    }
+}

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
@@ -15,7 +15,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
     {
         [Fact]
         [IsUnit]
-        public void MapAuthentication_WhenBasicAuthenticationDtoIsUsed_ThenIsMappedToBasicAuthenticationEntity()
+        public void MapAuthentication_When_BasicAuthenticationDtoIsUsed_Then_IsMappedToBasicAuthenticationEntity()
         {
             var sut = new DtoToEntityMapper();
 
@@ -37,7 +37,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
 
         [Fact]
         [IsUnit]
-        public void MapAuthentication_WhenOidcAuthenticationDtoIsUsed_ThenIsMappedToOidcAuthenticationEntity()
+        public void MapAuthentication_When_OidcAuthenticationDtoIsUsed_Then_IsMappedToOidcAuthenticationEntity()
         {
             var sut = new DtoToEntityMapper();
 
@@ -63,7 +63,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
 
         [Fact]
         [IsUnit]
-        public void MapUriTransform_WhenValidUriTransformIsUsed_ThenIsMappedToUriTransformEntity()
+        public void MapUriTransform_When_ValidUriTransformDtoIsUsed_Then_IsMappedToUriTransformEntity()
         {
             var sut = new DtoToEntityMapper();
 
@@ -86,7 +86,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
         [InlineData("PUT")]
         [InlineData("GET")]
         [IsUnit]
-        public void MapEndpoint_WhenValidEndpointIsUsed_ThenIsMappedToEndpointEntity(string httpVerb)
+        public void MapEndpoint_When_ValidEndpointDtoIsUsed_Then_IsMappedToEndpointEntity(string httpVerb)
         {
             var sut = new DtoToEntityMapper();
 
@@ -112,7 +112,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
         [InlineData("PUT")]
         [InlineData("GET")]
         [IsUnit]
-        public void MapAEndpoint_WhenValidEndpointIsUsed_ThenIsMappedToEndpointEntity(string httpVerb)
+        public void MapWebooks_When_ValidEndpointIsUsed_Then_IsMappedToEndpointEntity(string httpVerb)
         {
             var sut = new DtoToEntityMapper();
 

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/BasicAuthenticationDtoBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/BasicAuthenticationDtoBuilder.cs
@@ -6,7 +6,6 @@ namespace CaptainHook.TestsInfrastructure.Builders
     {
         public BasicAuthenticationDtoBuilder()
         {
-            With(x => x.AuthenticationType, "Basic");
             With(x => x.Username, "Batman");
             With(x => x.Password, "Batcave");
         }

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/OidcAuthenticationDtoBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/OidcAuthenticationDtoBuilder.cs
@@ -7,7 +7,6 @@ namespace CaptainHook.TestsInfrastructure.Builders
     {
         public OidcAuthenticationDtoBuilder()
         {
-            With(x => x.AuthenticationType, "OIDC");
             With(x => x.ClientId, "clientId");
             With(x => x.Uri, "https://security-api.com/token");
             With(x => x.Scopes, new List<string> { "test.scope.api" });

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/UriTransformDtoBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/UriTransformDtoBuilder.cs
@@ -1,0 +1,13 @@
+﻿using CaptainHook.Contract;
+using System.Collections.Generic;
+
+namespace CaptainHook.TestsInfrastructure.Builders
+{
+    public class UriTransformDtoBuilder : SimpleBuilder<UriTransformDto>
+    {
+        public UriTransformDtoBuilder()
+        {
+            With(e => e.Replace, new Dictionary<string, string>());
+        }
+    }
+}


### PR DESCRIPTION
The mapping code from DTOs to Entities has been extracted from handlers and moved to a separate service so all handlers can share the same piece of code.