### PR TITLE
Task 82576 enable selector mapping for requests

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
@@ -10,14 +10,14 @@ namespace CaptainHook.Application.Infrastructure.Mappers
         {
             return new WebhooksEntity(
                 webhooksDto.SelectionRule,
-                webhooksDto.Endpoints?.Select(MapEndpoint) ?? Enumerable.Empty<EndpointEntity>(),
+                webhooksDto.Endpoints?.Select(endpointDto => MapEndpoint(endpointDto)) ?? Enumerable.Empty<EndpointEntity>(),
                 MapUriTransform(webhooksDto.UriTransform));
         }
 
-        public EndpointEntity MapEndpoint(EndpointDto endpointDto)
+        public EndpointEntity MapEndpoint(EndpointDto endpointDto, string selector = null)
         {
             var authenticationEntity = MapAuthentication(endpointDto.Authentication);
-            var endpoint = new EndpointEntity(endpointDto.Uri, authenticationEntity, endpointDto.HttpVerb, endpointDto.Selector);
+            var endpoint = new EndpointEntity(endpointDto.Uri, authenticationEntity, endpointDto.HttpVerb, selector ?? endpointDto.Selector);
 
             return endpoint;
         }

--- a/src/CaptainHook.Application.Infrastructure/Mappers/IDtoToEntityMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/IDtoToEntityMapper.cs
@@ -16,8 +16,9 @@ namespace CaptainHook.Application.Infrastructure.Mappers
         /// Maps an Endpoint DTO to an Endpoint entity
         /// </summary>
         /// <param name="endpointDto">An Endpoint DTO</param>
+        /// <param name="selector"></param>
         /// <returns>An Endpoint entity</returns>
-        EndpointEntity MapEndpoint(EndpointDto endpointDto);
+        EndpointEntity MapEndpoint(EndpointDto endpointDto, string selector);
 
         /// <summary>
         /// Maps a URITransfrom DTO to a URITransform entity

--- a/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/UpsertWebhookRequestHandler.cs
@@ -124,7 +124,7 @@ namespace CaptainHook.Application.Handlers.Subscribers
         private EndpointEntity MapRequestToEndpointEntity(UpsertWebhookRequest request, SubscriberEntity parent)
         {
             return _dtoToEntityMapper
-                        .MapEndpoint(request.Endpoint)
+                        .MapEndpoint(request.Endpoint, request.Selector)
                         .SetParentSubscriber(parent);
         }
 

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/UpsertWebhookRequestHandlerTests.cs
@@ -56,7 +56,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
 
         public UpsertWebhookRequestHandlerTests()
         {
-            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>()))
+            _dtoToEntityMapper.Setup(r => r.MapEndpoint(It.IsAny<EndpointDto>(), _defaultUpsertRequest.Selector))
                 .Returns(new EndpointEntity(_defaultEndpointDto.Uri,
                     authentication: new OidcAuthenticationEntity(
                         clientId: ((OidcAuthenticationDto)_defaultEndpointDto.Authentication).ClientId,
@@ -103,7 +103,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Data.Should().BeEquivalentTo(_defaultUpsertRequest.Endpoint);
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
-            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>(), "*"), Times.Once);
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
         }
 
@@ -144,7 +144,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Error.Should().BeOfType<DirectorServiceIsBusyError>();
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
-            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>(), "*"), Times.Once);
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Never);
         }
 
@@ -164,7 +164,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.IsError.Should().BeTrue();
             result.Error.Should().BeOfType<ReaderCreateError>();
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
-            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>(), "*"), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Never);
         }
@@ -185,7 +185,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.IsError.Should().BeTrue();
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
-            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Once);
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>(), "*"), Times.Once);
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
         }
 
@@ -205,7 +205,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Should().BeEquivalentTo(expectedResult);
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Exactly(3));
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(3));
-            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Exactly(3));
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>(), "*"), Times.Exactly(3));
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(3));
         }
 
@@ -226,7 +226,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             result.Should().BeEquivalentTo(expectedResult);
             _repositoryMock.Verify(x => x.GetSubscriberAsync(It.IsAny<SubscriberId>()), Times.Exactly(2));
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(2));
-            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Exactly(2));
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>(), "*"), Times.Exactly(2));
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Exactly(2));
         }
 
@@ -254,7 +254,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
             _directorServiceMock.Verify(x => x.UpdateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
             _repositoryMock.Verify(x => x.UpdateSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
             _directorServiceMock.Verify(x => x.CreateReaderAsync(It.IsAny<SubscriberEntity>()), Times.Once);
-            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>()), Times.Exactly(2));
+            _dtoToEntityMapper.Verify(x => x.MapEndpoint(It.IsAny<EndpointDto>(), "*"), Times.Exactly(2));
             _repositoryMock.Verify(x => x.AddSubscriberAsync(It.IsAny<SubscriberEntity>()), Times.Once);
         }
 

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
@@ -96,8 +96,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
                 .With(x => x.Uri, "http://www.test.url")
                 .Create();
 
-
-            var entity = sut.MapEndpoint(dto);
+            var entity = sut.MapEndpoint(dto, null);
 
             using (new AssertionScope())
             {

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
@@ -106,6 +106,29 @@ namespace CaptainHook.Application.Tests.Infrastructure
             }
         }
 
+        [Fact, IsUnit]
+        public void MapEndpoint_When_ValidEndpointDtoIsUsedWithSelectorProvided_Then_IsMappedToEndpointEntity()
+        {
+            var sut = new DtoToEntityMapper();
+
+            var dto = new EndpointDtoBuilder()
+                .With(x => x.Selector, "Select")
+                .With(x => x.HttpVerb, "PUT")
+                .With(x => x.Uri, "http://www.test.url")
+                .With(x => x.Authentication, null)
+                .Create();
+
+            var entity = sut.MapEndpoint(dto, "abc");
+
+            var expectedEntity = new EndpointDto
+            {
+                Selector = "abc",
+                Uri = "http://www.test.url",
+                HttpVerb = "PUT"
+            };
+            entity.Should().BeEquivalentTo(expectedEntity);
+        }
+
         [Theory]
         [InlineData("POST")]
         [InlineData("PUT")]


### PR DESCRIPTION
### Why
For Webhook/Endpoint PUT requests, the selector has to be taken from the request itself. For Subscriber PUT requests it is taken from the payload. That small difference was lost during mapping creations.