### PR TITLE
#82787 Get subscriber details via API

### DIFF
--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClient.cs
@@ -1591,255 +1591,6 @@ namespace CaptainHook.Api.Client
         }
 
         /// <summary>
-        /// Get the configuration for the specified subscriber
-        /// </summary>
-        /// <param name='eventName'>
-        /// Event name
-        /// </param>
-        /// <param name='subscriberName'>
-        /// Subscriber name
-        /// </param>
-        /// <param name='customHeaders'>
-        /// Headers that will be added to request.
-        /// </param>
-        /// <param name='cancellationToken'>
-        /// The cancellation token.
-        /// </param>
-        /// <exception cref="HttpOperationException">
-        /// Thrown when the operation returned an invalid status code
-        /// </exception>
-        /// <exception cref="ValidationException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        /// <return>
-        /// A response object containing the response body and response headers.
-        /// </return>
-        public async Task<HttpOperationResponse> GetSubscriberWithHttpMessagesAsync(string eventName, string subscriberName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (eventName == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "eventName");
-            }
-            if (subscriberName == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "subscriberName");
-            }
-            // Tracing
-            bool _shouldTrace = ServiceClientTracing.IsEnabled;
-            string _invocationId = null;
-            if (_shouldTrace)
-            {
-                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
-                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
-                tracingParameters.Add("eventName", eventName);
-                tracingParameters.Add("subscriberName", subscriberName);
-                tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(_invocationId, this, "GetSubscriber", tracingParameters);
-            }
-            // Construct URL
-            var _baseUrl = BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/event/{eventName}/subscriber/{subscriberName}").ToString();
-            _url = _url.Replace("{eventName}", System.Uri.EscapeDataString(eventName));
-            _url = _url.Replace("{subscriberName}", System.Uri.EscapeDataString(subscriberName));
-            // Create HTTP transport objects
-            var _httpRequest = new HttpRequestMessage();
-            HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new HttpMethod("GET");
-            _httpRequest.RequestUri = new System.Uri(_url);
-            // Set Headers
-
-
-            if (customHeaders != null)
-            {
-                foreach(var _header in customHeaders)
-                {
-                    if (_httpRequest.Headers.Contains(_header.Key))
-                    {
-                        _httpRequest.Headers.Remove(_header.Key);
-                    }
-                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
-                }
-            }
-
-            // Serialize Request
-            string _requestContent = null;
-            // Set Credentials
-            if (Credentials != null)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                await Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
-            }
-            // Send Request
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
-            }
-            cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
-            }
-            HttpStatusCode _statusCode = _httpResponse.StatusCode;
-            cancellationToken.ThrowIfCancellationRequested();
-            string _responseContent = null;
-            if ((int)_statusCode != 200 && (int)_statusCode != 401 && (int)_statusCode != 404 && (int)_statusCode != 500 && (int)_statusCode != 503)
-            {
-                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                if (_httpResponse.Content != null) {
-                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                }
-                else {
-                    _responseContent = string.Empty;
-                }
-                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
-                if (_shouldTrace)
-                {
-                    ServiceClientTracing.Error(_invocationId, ex);
-                }
-                _httpRequest.Dispose();
-                if (_httpResponse != null)
-                {
-                    _httpResponse.Dispose();
-                }
-                throw ex;
-            }
-            // Create Result
-            var _result = new HttpOperationResponse();
-            _result.Request = _httpRequest;
-            _result.Response = _httpResponse;
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.Exit(_invocationId, _result);
-            }
-            return _result;
-        }
-
-        /// <summary>
-        /// Get the configuration for the specified event
-        /// </summary>
-        /// <param name='eventName'>
-        /// Event name
-        /// </param>
-        /// <param name='customHeaders'>
-        /// Headers that will be added to request.
-        /// </param>
-        /// <param name='cancellationToken'>
-        /// The cancellation token.
-        /// </param>
-        /// <exception cref="HttpOperationException">
-        /// Thrown when the operation returned an invalid status code
-        /// </exception>
-        /// <exception cref="ValidationException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        /// <return>
-        /// A response object containing the response body and response headers.
-        /// </return>
-        public async Task<HttpOperationResponse> GetEventSubscribersWithHttpMessagesAsync(string eventName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (eventName == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "eventName");
-            }
-            // Tracing
-            bool _shouldTrace = ServiceClientTracing.IsEnabled;
-            string _invocationId = null;
-            if (_shouldTrace)
-            {
-                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
-                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
-                tracingParameters.Add("eventName", eventName);
-                tracingParameters.Add("cancellationToken", cancellationToken);
-                ServiceClientTracing.Enter(_invocationId, this, "GetEventSubscribers", tracingParameters);
-            }
-            // Construct URL
-            var _baseUrl = BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/event/{eventName}").ToString();
-            _url = _url.Replace("{eventName}", System.Uri.EscapeDataString(eventName));
-            // Create HTTP transport objects
-            var _httpRequest = new HttpRequestMessage();
-            HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new HttpMethod("GET");
-            _httpRequest.RequestUri = new System.Uri(_url);
-            // Set Headers
-
-
-            if (customHeaders != null)
-            {
-                foreach(var _header in customHeaders)
-                {
-                    if (_httpRequest.Headers.Contains(_header.Key))
-                    {
-                        _httpRequest.Headers.Remove(_header.Key);
-                    }
-                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
-                }
-            }
-
-            // Serialize Request
-            string _requestContent = null;
-            // Set Credentials
-            if (Credentials != null)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                await Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
-            }
-            // Send Request
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
-            }
-            cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
-            }
-            HttpStatusCode _statusCode = _httpResponse.StatusCode;
-            cancellationToken.ThrowIfCancellationRequested();
-            string _responseContent = null;
-            if ((int)_statusCode != 200 && (int)_statusCode != 401 && (int)_statusCode != 404 && (int)_statusCode != 500 && (int)_statusCode != 503)
-            {
-                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                if (_httpResponse.Content != null) {
-                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                }
-                else {
-                    _responseContent = string.Empty;
-                }
-                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
-                if (_shouldTrace)
-                {
-                    ServiceClientTracing.Error(_invocationId, ex);
-                }
-                _httpRequest.Dispose();
-                if (_httpResponse != null)
-                {
-                    _httpResponse.Dispose();
-                }
-                throw ex;
-            }
-            // Create Result
-            var _result = new HttpOperationResponse();
-            _result.Request = _httpRequest;
-            _result.Response = _httpResponse;
-            if (_shouldTrace)
-            {
-                ServiceClientTracing.Exit(_invocationId, _result);
-            }
-            return _result;
-        }
-
-        /// <summary>
         /// Returns a probe result
         /// </summary>
         /// <param name='customHeaders'>
@@ -2017,6 +1768,126 @@ namespace CaptainHook.Api.Client
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200 && (int)_statusCode != 401 && (int)_statusCode != 500 && (int)_statusCode != 503)
+            {
+                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                if (_httpResponse.Content != null) {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                else {
+                    _responseContent = string.Empty;
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+
+        /// <summary>
+        /// Get the configuration for the specified subscriber
+        /// </summary>
+        /// <param name='eventAndSubscriberNameKey'>
+        /// Event and subscriber name key
+        /// </param>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse> GetSubscriberWithHttpMessagesAsync(string eventAndSubscriberNameKey, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (eventAndSubscriberNameKey == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "eventAndSubscriberNameKey");
+            }
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("eventAndSubscriberNameKey", eventAndSubscriberNameKey);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "GetSubscriber", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = BaseUri.AbsoluteUri;
+            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "api/subscribers/{eventAndSubscriberNameKey}").ToString();
+            _url = _url.Replace("{eventAndSubscriberNameKey}", System.Uri.EscapeDataString(eventAndSubscriberNameKey));
+            // Create HTTP transport objects
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
+            _httpRequest.RequestUri = new System.Uri(_url);
+            // Set Headers
+
+
+            if (customHeaders != null)
+            {
+                foreach(var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            // Set Credentials
+            if (Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 200 && (int)_statusCode != 401 && (int)_statusCode != 404 && (int)_statusCode != 500 && (int)_statusCode != 503)
             {
                 var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
                 if (_httpResponse.Content != null) {

--- a/src/CaptainHook.Api.Client/ApiClient/CaptainHookClientExtensions.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/CaptainHookClientExtensions.cs
@@ -373,111 +373,6 @@ namespace CaptainHook.Api.Client
             }
 
             /// <summary>
-            /// Get the configuration for the specified subscriber
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='eventName'>
-            /// Event name
-            /// </param>
-            /// <param name='subscriberName'>
-            /// Subscriber name
-            /// </param>
-            public static void GetSubscriber(this ICaptainHookClient operations, string eventName, string subscriberName)
-            {
-                operations.GetSubscriberAsync(eventName, subscriberName).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Get the configuration for the specified subscriber
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='eventName'>
-            /// Event name
-            /// </param>
-            /// <param name='subscriberName'>
-            /// Subscriber name
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task GetSubscriberAsync(this ICaptainHookClient operations, string eventName, string subscriberName, CancellationToken cancellationToken = default(CancellationToken))
-            {
-                (await operations.GetSubscriberWithHttpMessagesAsync(eventName, subscriberName, null, cancellationToken).ConfigureAwait(false)).Dispose();
-            }
-
-            /// <summary>
-            /// Get the configuration for the specified subscriber
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='eventName'>
-            /// Event name
-            /// </param>
-            /// <param name='subscriberName'>
-            /// Subscriber name
-            /// </param>
-            /// <param name='customHeaders'>
-            /// Headers that will be added to request.
-            /// </param>
-            public static HttpOperationResponse GetSubscriberWithHttpMessages(this ICaptainHookClient operations, string eventName, string subscriberName, Dictionary<string, List<string>> customHeaders = null)
-            {
-                return operations.GetSubscriberWithHttpMessagesAsync(eventName, subscriberName, customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Get the configuration for the specified event
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='eventName'>
-            /// Event name
-            /// </param>
-            public static void GetEventSubscribers(this ICaptainHookClient operations, string eventName)
-            {
-                operations.GetEventSubscribersAsync(eventName).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
-            /// Get the configuration for the specified event
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='eventName'>
-            /// Event name
-            /// </param>
-            /// <param name='cancellationToken'>
-            /// The cancellation token.
-            /// </param>
-            public static async Task GetEventSubscribersAsync(this ICaptainHookClient operations, string eventName, CancellationToken cancellationToken = default(CancellationToken))
-            {
-                (await operations.GetEventSubscribersWithHttpMessagesAsync(eventName, null, cancellationToken).ConfigureAwait(false)).Dispose();
-            }
-
-            /// <summary>
-            /// Get the configuration for the specified event
-            /// </summary>
-            /// <param name='operations'>
-            /// The operations group for this extension method.
-            /// </param>
-            /// <param name='eventName'>
-            /// Event name
-            /// </param>
-            /// <param name='customHeaders'>
-            /// Headers that will be added to request.
-            /// </param>
-            public static HttpOperationResponse GetEventSubscribersWithHttpMessages(this ICaptainHookClient operations, string eventName, Dictionary<string, List<string>> customHeaders = null)
-            {
-                return operations.GetEventSubscribersWithHttpMessagesAsync(eventName, customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-
-            /// <summary>
             /// Returns a probe result
             /// </summary>
             /// <param name='operations'>
@@ -553,6 +448,54 @@ namespace CaptainHook.Api.Client
             public static HttpOperationResponse GetAllWithHttpMessages(this ICaptainHookClient operations, Dictionary<string, List<string>> customHeaders = null)
             {
                 return operations.GetAllWithHttpMessagesAsync(customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get the configuration for the specified subscriber
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='eventAndSubscriberNameKey'>
+            /// Event and subscriber name key
+            /// </param>
+            public static void GetSubscriber(this ICaptainHookClient operations, string eventAndSubscriberNameKey)
+            {
+                operations.GetSubscriberAsync(eventAndSubscriberNameKey).GetAwaiter().GetResult();
+            }
+
+            /// <summary>
+            /// Get the configuration for the specified subscriber
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='eventAndSubscriberNameKey'>
+            /// Event and subscriber name key
+            /// </param>
+            /// <param name='cancellationToken'>
+            /// The cancellation token.
+            /// </param>
+            public static async Task GetSubscriberAsync(this ICaptainHookClient operations, string eventAndSubscriberNameKey, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                (await operations.GetSubscriberWithHttpMessagesAsync(eventAndSubscriberNameKey, null, cancellationToken).ConfigureAwait(false)).Dispose();
+            }
+
+            /// <summary>
+            /// Get the configuration for the specified subscriber
+            /// </summary>
+            /// <param name='operations'>
+            /// The operations group for this extension method.
+            /// </param>
+            /// <param name='eventAndSubscriberNameKey'>
+            /// Event and subscriber name key
+            /// </param>
+            /// <param name='customHeaders'>
+            /// Headers that will be added to request.
+            /// </param>
+            public static HttpOperationResponse GetSubscriberWithHttpMessages(this ICaptainHookClient operations, string eventAndSubscriberNameKey, Dictionary<string, List<string>> customHeaders = null)
+            {
+                return operations.GetSubscriberWithHttpMessagesAsync(eventAndSubscriberNameKey, customHeaders, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
     }

--- a/src/CaptainHook.Api.Client/ApiClient/ICaptainHookClient.cs
+++ b/src/CaptainHook.Api.Client/ApiClient/ICaptainHookClient.cs
@@ -144,37 +144,6 @@ namespace CaptainHook.Api.Client
         Task<HttpOperationResponse<object>> DeleteSubscriberWithHttpMessagesAsync(string eventName, string subscriberName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Get the configuration for the specified subscriber
-        /// </summary>
-        /// <param name='eventName'>
-        /// Event name
-        /// </param>
-        /// <param name='subscriberName'>
-        /// Subscriber name
-        /// </param>
-        /// <param name='customHeaders'>
-        /// The headers that will be added to request.
-        /// </param>
-        /// <param name='cancellationToken'>
-        /// The cancellation token.
-        /// </param>
-        Task<HttpOperationResponse> GetSubscriberWithHttpMessagesAsync(string eventName, string subscriberName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Get the configuration for the specified event
-        /// </summary>
-        /// <param name='eventName'>
-        /// Event name
-        /// </param>
-        /// <param name='customHeaders'>
-        /// The headers that will be added to request.
-        /// </param>
-        /// <param name='cancellationToken'>
-        /// The cancellation token.
-        /// </param>
-        Task<HttpOperationResponse> GetEventSubscribersWithHttpMessagesAsync(string eventName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
         /// Returns a probe result
         /// </summary>
         /// <param name='customHeaders'>
@@ -195,6 +164,20 @@ namespace CaptainHook.Api.Client
         /// The cancellation token.
         /// </param>
         Task<HttpOperationResponse> GetAllWithHttpMessagesAsync(Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Get the configuration for the specified subscriber
+        /// </summary>
+        /// <param name='eventAndSubscriberNameKey'>
+        /// Event and subscriber name key
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        Task<HttpOperationResponse> GetSubscriberWithHttpMessagesAsync(string eventAndSubscriberNameKey, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
     }
 }

--- a/src/Tests/CaptainHook.Api.Tests/Integration/EventsControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Integration/EventsControllerTests.cs
@@ -82,56 +82,6 @@ namespace CaptainHook.Api.Tests.Integration
             result.Response.StatusCode.Should().Be(StatusCodes.Status201Created);
         }
 
-        [Fact, IsIntegration]
-        public async Task GetSubscriber_WhenUnauthenticated_Returns401Unauthorized()
-        {
-            // Act
-            var result = await UnauthenticatedClient.GetSubscriberWithHttpMessagesAsync(IntegrationTestEventName, _subscriberName);
-
-            // Assert
-            result.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-        }
-
-        [Fact, IsIntegration]
-        public async Task GetSubscriber_WhenAuthenticated_Returns200AndData()
-        {
-            // Act
-            var result = await AuthenticatedClient.GetSubscriberWithHttpMessagesAsync(IntegrationTestEventName, _subscriberName);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                result.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-                var content = await result.Response.Content.ReadAsStringAsync();
-                content.Should().NotBeNullOrEmpty();
-            }
-        }
-
-        [Fact, IsIntegration]
-        public async Task GetEventSubscribers_WhenUnauthenticated_Returns401Unauthorized()
-        {
-            // Act
-            var result = await UnauthenticatedClient.GetEventSubscribersWithHttpMessagesAsync(IntegrationTestEventName);
-
-            // Assert
-            result.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-        }
-
-        [Fact, IsIntegration]
-        public async Task GetEventSubscribers_WhenAuthenticated_Returns200AndData()
-        {
-            // Act
-            var result = await AuthenticatedClient.GetEventSubscribersWithHttpMessagesAsync(IntegrationTestEventName);
-
-            // Assert
-            using (new AssertionScope())
-            {
-                result.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-                var content = await result.Response.Content.ReadAsStringAsync();
-                content.Should().NotBeNullOrEmpty();
-            }
-        }
-
         private CaptainHookContractSubscriberDto GetTestSubscriberDto()
         {
             var webhookDto = new CaptainHookContractWebhooksDto(endpoints: new[]

--- a/src/Tests/CaptainHook.Api.Tests/Integration/SubscribersControllerTests.cs
+++ b/src/Tests/CaptainHook.Api.Tests/Integration/SubscribersControllerTests.cs
@@ -40,5 +40,31 @@ namespace CaptainHook.Api.Tests.Integration
                 content.Should().NotBeNullOrEmpty();
             }
         }
+
+        [Fact, IsIntegration]
+        public async Task GetSubscriber_WhenUnauthenticated_Returns401Unauthorized()
+        {
+            // Act
+            var result = await UnauthenticatedClient.GetSubscriberWithHttpMessagesAsync("core.events.test.trackingdomainevent;captain-hook");
+
+            // Assert
+            result.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        }
+
+        [Fact, IsIntegration]
+        public async Task GetSubscriber_WhenAuthenticated_Returns200AndData()
+        {
+            // Act
+            var result = await AuthenticatedClient.GetSubscriberWithHttpMessagesAsync("core.events.test.trackingdomainevent;captain-hook");
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+                var content = await result.Response.Content.ReadAsStringAsync();
+                content.Should().NotBeNullOrEmpty();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This is a different implementation of the Get Subscriber API which comes after a conversation with @chomick .
The endpoint has been moved to the Subscriber controller to leave the Event one clean and consistent with the rest of the architecture. The new Get operation resides in the temporary Subscriber controller along with the GetAll where does not utilizes a well-defined contract until the whole API is complete.
