### PR TITLE
#85983 - move configure eda command to a new namespace

### DIFF
--- a/src/CaptainHook.Cli/Commands/ConfigureEda/ApiClientFixture.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/ApiClientFixture.cs
@@ -3,7 +3,7 @@ using CaptainHook.Api.Client;
 using EShopworld.Security.Services.Testing.Settings;
 using EShopworld.Security.Services.Testing.Token;
 
-namespace CaptainHook.Cli.Commands.ExecuteApi
+namespace CaptainHook.Cli.Commands.ConfigureEda
 {
     public class ApiClientFixture
     {

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/ApiConsumer.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/ApiConsumer.cs
@@ -4,15 +4,14 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using CaptainHook.Api.Client;
-using CaptainHook.Cli.Commands.ExecuteApi.Models;
+using CaptainHook.Cli.Commands.ConfigureEda.Models;
 using CaptainHook.Cli.Common;
-using CaptainHook.Domain.Errors;
 using CaptainHook.Domain.Results;
 using Microsoft.Rest;
 using Polly;
 using Polly.Retry;
 
-namespace CaptainHook.Cli.Commands.ExecuteApi
+namespace CaptainHook.Cli.Commands.ConfigureEda
 {
     public class ApiConsumer
     {

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
@@ -7,16 +7,16 @@ using CaptainHook.Api.Client;
 using CaptainHook.Cli.Extensions;
 using McMaster.Extensions.CommandLineUtils;
 
-namespace CaptainHook.Cli.Commands.ExecuteApi
+namespace CaptainHook.Cli.Commands.ConfigureEda
 {
     [Command("configure-eda", Description = "Processes configuration in the provided location and calls Captain Hook API to create/update subscribers")]
     [HelpOption]
-    public class ExecuteApiCommand
+    public class ConfigureEdaCommand
     {
         private readonly IFileSystem _fileSystem;
         private readonly ICaptainHookClient _captainHookClient;
 
-        public ExecuteApiCommand(IFileSystem fileSystem, ICaptainHookClient captainHookClient)
+        public ConfigureEdaCommand(IFileSystem fileSystem, ICaptainHookClient captainHookClient)
         {
             _fileSystem = fileSystem;
             _captainHookClient = captainHookClient;

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/ConsoleSubscriberWriter.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/ConsoleSubscriberWriter.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using CaptainHook.Cli.Commands.ExecuteApi.Models;
+using CaptainHook.Cli.Commands.ConfigureEda.Models;
 using McMaster.Extensions.CommandLineUtils;
 
-namespace CaptainHook.Cli.Commands.ExecuteApi
+namespace CaptainHook.Cli.Commands.ConfigureEda
 {
     public class ConsoleSubscriberWriter
     {

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/Models/PutSubscriberFile.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/Models/PutSubscriberFile.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace CaptainHook.Cli.Commands.ExecuteApi.Models
+namespace CaptainHook.Cli.Commands.ConfigureEda.Models
 {
     public class PutSubscriberFile
     {

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/Models/PutSubscriberRequest.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/Models/PutSubscriberRequest.cs
@@ -1,6 +1,6 @@
 ﻿using CaptainHook.Api.Client.Models;
 
-namespace CaptainHook.Cli.Commands.ExecuteApi.Models
+namespace CaptainHook.Cli.Commands.ConfigureEda.Models
 {
     public class PutSubscriberRequest
     {

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/SubscribersDirectoryProcessor.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/SubscribersDirectoryProcessor.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
-using CaptainHook.Cli.Commands.ExecuteApi.Models;
+using CaptainHook.Cli.Commands.ConfigureEda.Models;
 using CaptainHook.Cli.Common;
 using CaptainHook.Domain.Results;
 using Newtonsoft.Json;
 
-namespace CaptainHook.Cli.Commands.ExecuteApi
+namespace CaptainHook.Cli.Commands.ConfigureEda
 {
     public class SubscribersDirectoryProcessor
     {

--- a/src/CaptainHook.Cli/Program.cs
+++ b/src/CaptainHook.Cli/Program.cs
@@ -7,7 +7,7 @@ using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Reflection;
-using CaptainHook.Cli.Commands.ExecuteApi;
+using CaptainHook.Cli.Commands.ConfigureEda;
 
 namespace CaptainHook.Cli
 {
@@ -17,7 +17,7 @@ namespace CaptainHook.Cli
     [Command(Name = "ch", Description = "CaptainHook CLI")]
     [Subcommand(typeof(GenerateJsonCommand))]
     [Subcommand(typeof(GeneratePowerShellCommand))]
-    [Subcommand(typeof(ExecuteApiCommand))]
+    [Subcommand(typeof(ConfigureEdaCommand))]
     [VersionOptionFromMember("--version", MemberName = nameof(GetVersion))]
     public class Program
     {


### PR DESCRIPTION
Since the command has changed, its namespaces should too.