### PR TITLE
#86177 - rename the output cli to platform.eda.cli.exe

### DIFF
--- a/src/CaptainHook.Application/Validators/Dtos/SubscriberDtoValidator.cs
+++ b/src/CaptainHook.Application/Validators/Dtos/SubscriberDtoValidator.cs
@@ -13,6 +13,9 @@ namespace CaptainHook.Application.Validators.Dtos
 
             RuleFor(x => x.Callbacks)
                 .SetValidator(new WebhooksDtoValidator("Callbacks"));
+
+            RuleFor(x => x.DlqHooks)
+                .SetValidator(new WebhooksDtoValidator("DlqHooks"));
         }
     }
 }

--- a/src/CaptainHook.Cli/CaptainHook.Cli.csproj
+++ b/src/CaptainHook.Cli/CaptainHook.Cli.csproj
@@ -6,6 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>dotnet-ch</PackageId>
     <Platforms>AnyCPU;x64</Platforms>
+    <AssemblyName>Platform.Eda.Cli</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Contract/SubscriberDto.cs
+++ b/src/CaptainHook.Contract/SubscriberDto.cs
@@ -5,5 +5,7 @@
         public WebhooksDto Webhooks { get; set; }
 
         public WebhooksDto Callbacks { get; set; }
+        
+        public WebhooksDto DlqHooks { get; set; }
     }
 }

--- a/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertSubscriberRequestValidatorTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertSubscriberRequestValidatorTests.cs
@@ -91,6 +91,17 @@ namespace CaptainHook.Application.Tests.RequestValidators
             result.ShouldNotHaveAnyValidationErrors();
         }
 
+        [Fact, IsUnit]
+        public void When_DlqIsEmpty_Then_NoFailuresReturned()
+        {
+            var dto = new SubscriberDtoBuilder().With(x => x.DlqHooks, null).Create();
+            var request = new UpsertSubscriberRequest("event", "subscriber", dto);
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
         [Theory, IsUnit]
         [ClassData(typeof(InvalidJsonPaths))]
         public void When_WebhooksSelectionRuleIsNotValidJsonPath_Then_ValidationFails(string jsonPath)

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberDtoBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberDtoBuilder.cs
@@ -8,6 +8,7 @@ namespace CaptainHook.TestsInfrastructure.Builders
         {
             With(e => e.Webhooks, new WebhooksDtoBuilder().Create());
             With(e => e.Callbacks, new WebhooksDtoBuilder().Create());
+            With(e => e.DlqHooks, new WebhooksDtoBuilder().Create());
         }
     }
 }


### PR DESCRIPTION
With this change, I would like to suggest that:

1. The generated CLI will be `Platform.Eda.Cli.exe`
1. The project name remains `CaptainHook.Cli` in VS
1. The default namespace remains `CaptainHook.Cli`

Points 2 and 3 are mainly there to limit the changes, as by aligning everything we really don't benefit in anything.

Let me know what you think!