### PR TITLE
#86026 - process subscribers independently

### DIFF
--- a/src/CaptainHook.Cli/Commands/ConfigureEda/ConsoleSubscriberWriter.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/ConsoleSubscriberWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using CaptainHook.Cli.Commands.ConfigureEda.Models;
 using McMaster.Extensions.CommandLineUtils;
@@ -14,7 +15,7 @@ namespace CaptainHook.Cli.Commands.ConfigureEda
             _console = console;
         }
 
-        public void OutputSubscribers(IEnumerable<PutSubscriberFile> subscriberFiles)
+        public void OutputSubscribers(IEnumerable<PutSubscriberFile> subscriberFiles, string inputFolderPath)
         {
             var files = subscriberFiles?.ToArray();
             if (files == null || !files.Any())
@@ -23,11 +24,13 @@ namespace CaptainHook.Cli.Commands.ConfigureEda
                 return;
             }
 
-            // ReSharper disable once PossibleNullReferenceException as it is checked in the statement above
+            var sourceFolderPath = Path.GetFullPath(inputFolderPath);
             foreach (var file in files)
             {
-                _console.WriteLine($"File '{file.File.Name}' has been found");
+                var fileRelativePath = Path.GetRelativePath(sourceFolderPath, file.File.FullName);
+                _console.WriteLine($"File '{fileRelativePath}' has been found");
             }
         }
+
     }
 }

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/Models/ApiOperationResult.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/Models/ApiOperationResult.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using CaptainHook.Domain.Results;
+using Microsoft.Rest;
+
+namespace CaptainHook.Cli.Commands.ConfigureEda.Models
+{
+    public class ApiOperationResult
+    {
+        public FileInfo File { get; set; }
+
+        public OperationResult<HttpOperationResponse> Response { get; set; }
+    }
+}

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/SubscribersDirectoryProcessor.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/SubscribersDirectoryProcessor.cs
@@ -30,7 +30,7 @@ namespace CaptainHook.Cli.Commands.ConfigureEda
 
             try
             {
-                var subscriberFiles = _fileSystem.Directory.GetFiles(sourceFolderPath, "*.json");
+                var subscriberFiles = _fileSystem.Directory.GetFiles(sourceFolderPath, "*.json", SearchOption.AllDirectories);
                 foreach (var fileName in subscriberFiles)
                 {
                     var content = _fileSystem.File.ReadAllText(fileName);


### PR DESCRIPTION
The goal is to be able for the CLI to process files/subscribers individually where error in one does not affect processing of the other. The output is also improved to reflect the fact that we now look into all the children folders and its files as well:

![image](https://user-images.githubusercontent.com/60343978/93513529-46325a80-f926-11ea-834c-81f42d8b1209.png)

Remark:
No proper error handling is included at the moment, I will try to circle back here.
