### PR TITLE
Task 86026 process subscribers independently

### DIFF
--- a/src/CaptainHook.Cli/CaptainHook.Cli.csproj
+++ b/src/CaptainHook.Cli/CaptainHook.Cli.csproj
@@ -26,9 +26,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <DependentUpon>appsettings.json</DependentUpon>
     </Content>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="appsettings.PREP.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <DependentUpon>appsettings.json</DependentUpon>
@@ -36,6 +33,9 @@
     <Content Include="appsettings.TEST.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <DependentUpon>appsettings.json</DependentUpon>
+    </Content>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/src/CaptainHook.Cli/Commands/ConfigureEda/ConsoleSubscriberWriter.cs
+++ b/src/CaptainHook.Cli/Commands/ConfigureEda/ConsoleSubscriberWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CaptainHook.Cli.Commands.ConfigureEda.Models;
@@ -32,5 +33,31 @@ namespace CaptainHook.Cli.Commands.ConfigureEda
             }
         }
 
+        public void WriteNormal(params string[] lines) => WriteInColor(_console.ForegroundColor, lines);
+
+        public void WriteSuccess(params string[] lines) => WriteInColor(ConsoleColor.DarkGreen, lines);
+
+        public void WriteError(params string[] lines) => WriteInColor(ConsoleColor.Red, lines);
+
+        private void WriteBox(int length) => _console.WriteLine(new string('=', length));
+
+        private void WriteInColor(ConsoleColor color, params string[] lines)
+        {
+            Action writeBox = null;
+
+            if (lines.Length > 1 && string.Equals("box", lines[0], StringComparison.OrdinalIgnoreCase))
+            {
+                var longestLine = lines.Skip(1).Max(l => l.Length);
+                writeBox = () => WriteBox(longestLine);
+            }
+
+            var line = string.Join(Environment.NewLine, writeBox == null ? lines : lines.Skip(1));
+            _console.ForegroundColor = color;
+            
+            writeBox?.Invoke();
+            _console.WriteLine(line);
+            writeBox?.Invoke();
+            _console.ResetColor();
+        }
     }
 }


### PR DESCRIPTION
With this PR I am focusing on:
- handling errors with API communication and retrying 3 times total
- 201 and 202 are the only accepted answers
- success/failure status is output to the console using color
- some arguments are optimised

The result of the operation of the CLI:

![image](https://user-images.githubusercontent.com/60343978/93601734-eb4e4100-f9c1-11ea-9c96-17ccd25e8a72.png)
![image](https://user-images.githubusercontent.com/60343978/93601787-002ad480-f9c2-11ea-80c0-0aac490abd2c.png)
