### PR TITLE
#86028 - cover ApiConsumer with unit tests

### DIFF
--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/ApiConsumer.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/ApiConsumer.cs
@@ -57,13 +57,13 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda
                     yield return new ApiOperationResult
                     {
                         File = file.File,
-                        Response = await BuildExecutionError(response.Response)
+                        Response = await BuildExecutionErrorAsync(response.Response)
                     };
                 }
             }
         }
 
-        private static async Task<CliExecutionError> BuildExecutionError(HttpResponseMessage response)
+        private static async Task<CliExecutionError> BuildExecutionErrorAsync(HttpResponseMessage response)
         {
             var responseString = "(none)";
             if (response.Content != null)

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
@@ -98,7 +98,7 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda
             ConsoleSubscriberWriter writer,
             IEnumerable<PutSubscriberFile> subscriberFiles)
         {
-            var api = new ApiConsumer(_captainHookClient);
+            var api = new ApiConsumer(_captainHookClient, null);
             var apiResults = new List<OperationResult<HttpOperationResponse>>();
 
             var sourceFolderPath = Path.GetFullPath(InputFolderPath);

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/Models/ApiOperationResult.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/Models/ApiOperationResult.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿using System.IO.Abstractions;
 using CaptainHook.Domain.Results;
 using Microsoft.Rest;
 
@@ -6,7 +6,7 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda.Models
 {
     public class ApiOperationResult
     {
-        public FileInfo File { get; set; }
+        public FileInfoBase File { get; set; }
 
         public OperationResult<HttpOperationResponse> Response { get; set; }
     }

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/Models/PutSubscriberFile.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/Models/PutSubscriberFile.cs
@@ -1,10 +1,10 @@
-﻿using System.IO;
+﻿using System.IO.Abstractions;
 
 namespace Platform.Eda.Cli.Commands.ConfigureEda.Models
 {
     public class PutSubscriberFile
     {
-        public FileInfo File { get; set; }
+        public FileInfoBase File { get; set; }
 
         public PutSubscriberRequest Request { get; set; }
     }

--- a/src/Tests/Platform.Eda.Cli.Tests/ConfigureEda/ApiConsumerTests.cs
+++ b/src/Tests/Platform.Eda.Cli.Tests/ConfigureEda/ApiConsumerTests.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using CaptainHook.Api.Client;
+using CaptainHook.Api.Client.Models;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using Microsoft.Rest;
+using Moq;
+using Platform.Eda.Cli.Commands.ConfigureEda;
+using Platform.Eda.Cli.Commands.ConfigureEda.Models;
+using Platform.Eda.Cli.Common;
+using Xunit;
+
+namespace Platform.Eda.Cli.Tests.ConfigureEda
+{
+    public class ApiConsumerTests
+    {
+        private readonly Mock<ICaptainHookClient> _apiClientMock = new Mock<ICaptainHookClient>();
+
+        private readonly ApiConsumer _apiConsumer;
+
+        private readonly HttpOperationResponse<object> _positiveResponse = new HttpOperationResponse<object>
+        {
+            Response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Accepted
+            }
+        };
+
+        private readonly HttpOperationResponse<object> _negativeResponse = new HttpOperationResponse<object>
+        {
+            Response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent("test-content")
+            }
+        };
+
+        private readonly FileInfoBase _fileInfo = Mock.Of<FileInfoBase>();
+
+        public ApiConsumerTests()
+        {
+            _apiConsumer = new ApiConsumer(_apiClientMock.Object, new[] { TimeSpan.FromMilliseconds(50.0) });
+        }
+
+        [Fact, IsUnit]
+        public async Task CallApiAsync_OneFileToProcess_SingleResultSuccessful()
+        {
+            // Arrange
+            _apiClientMock
+                .Setup(s => s.PutSuscriberWithHttpMessagesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CaptainHookContractSubscriberDto>(),
+                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_positiveResponse);
+            var files = new[]
+            {
+                new PutSubscriberFile
+                {
+                    File = _fileInfo,
+                    Request = new PutSubscriberRequest()
+                }
+            };
+
+            // Act
+            var results = await GetAll(_apiConsumer.CallApiAsync(files));
+
+            // Assert
+            var expected = new[]
+            {
+                new ApiOperationResult { File = _fileInfo, Response = _positiveResponse }
+            };
+
+            results.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact, IsUnit]
+        public async Task CallApiAsync_TwoFileToProcess_TwoResultSuccessful()
+        {
+            // Arrange
+            _apiClientMock
+                .Setup(s => s.PutSuscriberWithHttpMessagesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CaptainHookContractSubscriberDto>(),
+                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_positiveResponse);
+            var files = new[]
+            {
+                new PutSubscriberFile
+                {
+                    File = _fileInfo,
+                    Request = new PutSubscriberRequest()
+                },
+                new PutSubscriberFile
+                {
+                    File = _fileInfo,
+                    Request = new PutSubscriberRequest()
+                }
+            };
+
+            // Act
+            var results = await GetAll(_apiConsumer.CallApiAsync(files));
+
+            // Assert
+            var expected = new[]
+            {
+                new ApiOperationResult { File = _fileInfo, Response = _positiveResponse },
+                new ApiOperationResult { File = _fileInfo, Response = _positiveResponse },
+            };
+
+            results.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact, IsUnit]
+        public async Task CallApiAsync_TwoFileToProcessFirstOneFails_ResultsInSuccessAndFailure()
+        {
+            // Arrange
+            _apiClientMock.SetupSequence(s => s.PutSuscriberWithHttpMessagesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CaptainHookContractSubscriberDto>(),
+                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_positiveResponse)
+                .ReturnsAsync(_negativeResponse) //1st call for 2nd file
+                .ReturnsAsync(_negativeResponse); //2nd call for 2nd file
+            var files = new[]
+            {
+                new PutSubscriberFile
+                {
+                    File = _fileInfo,
+                    Request = new PutSubscriberRequest()
+                },
+                new PutSubscriberFile
+                {
+                    File = _fileInfo,
+                    Request = new PutSubscriberRequest()
+                }
+            };
+
+            // Act
+            var results = await GetAll(_apiConsumer.CallApiAsync(files));
+
+            // Assert
+            var expected = new[]
+            {
+                new ApiOperationResult { File = _fileInfo, Response = _positiveResponse },
+                new ApiOperationResult { File = _fileInfo, Response = new CliExecutionError("Status code: 400\r\nReason: Bad Request\r\nResponse: test-content") },
+            };
+
+            results.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact, IsUnit]
+        public async Task CallApiAsync_OneFileToProcessExpectedToFail_TwoCallsAreMade()
+        {
+            // Arrange
+            _apiClientMock.SetupSequence(s => s.PutSuscriberWithHttpMessagesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CaptainHookContractSubscriberDto>(),
+                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_negativeResponse) //1st call for 2nd file
+                .ReturnsAsync(_negativeResponse); //2nd call for 2nd file
+            var files = new[]
+            {
+                new PutSubscriberFile
+                {
+                    File = _fileInfo,
+                    Request = new PutSubscriberRequest()
+                }
+            };
+
+            // Act
+            var _ = await GetAll(_apiConsumer.CallApiAsync(files));
+
+            // Assert
+            _apiClientMock.Verify(s => s.PutSuscriberWithHttpMessagesAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CaptainHookContractSubscriberDto>(),
+                It.IsAny<Dictionary<string, List<string>>>(),
+                It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        private static async Task<IEnumerable<T>> GetAll<T>(IAsyncEnumerable<T> enumerable)
+        {
+            var list = new List<T>();
+            await foreach (var item in enumerable)
+            {
+                list.Add(item);
+            }
+
+            return list;
+        }
+    }
+}


### PR DESCRIPTION
With this PR I am covering ApiConsumer with unit tests. The reported coverage is 100% for dotCover.

1. SleepTimes are configurable to so that unit tests do not need to wait too long
2. App has been run locally to verify that it's working due to some refactorings made.