### PR TITLE
#86475 Deal with readonly dictionary in domain entity

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
@@ -12,6 +12,8 @@ namespace CaptainHook.Application.Infrastructure.Mappers
 {
     public class SubscriberEntityToConfigurationMapper : ISubscriberEntityToConfigurationMapper
     {
+        private static readonly Dictionary<string, string> EmptyReplacementsDictionary = new Dictionary<string, string>();
+
         private static readonly WebhookRequestRule StatusCodeRequestRule = new WebhookRequestRule
         {
             Source = new SourceParserLocation
@@ -129,7 +131,7 @@ namespace CaptainHook.Application.Infrastructure.Mappers
 
         private async Task<OperationResult<WebhookConfig>> MapForUriTransformAsync(string name, string eventType, WebhooksEntity webhooksEntity)
         {
-            var replacements = webhooksEntity.UriTransform?.Replace ?? new Dictionary<string, string>();
+            var replacements = new Dictionary<string, string>(webhooksEntity.UriTransform?.Replace ?? EmptyReplacementsDictionary);
 
             if (!string.IsNullOrEmpty(webhooksEntity.SelectionRule))
             {

--- a/src/CaptainHook.Domain/Entities/UriTransformEntity.cs
+++ b/src/CaptainHook.Domain/Entities/UriTransformEntity.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace CaptainHook.Domain.Entities
 {
@@ -11,7 +12,7 @@ namespace CaptainHook.Domain.Entities
 
         public UriTransformEntity(IDictionary<string, string> replace)
         {
-            Replace = replace;
+            Replace = new ReadOnlyDictionary<string, string>(replace ?? new Dictionary<string, string>());
         }
     }
 }

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests.cs
@@ -505,7 +505,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
         [MemberData(nameof(Data))]
         public async Task MapSubscriberAsync_WithSingleWebhookAndInvalidUriTransform_MapsToRouteAndReplace(string httpVerb, AuthenticationEntity authentication, AuthenticationConfig expectedAuthenticationConfig)
         {
-            var uriTransform = new UriTransformEntity(null);
+            var uriTransform = new UriTransformEntity(new Dictionary<string, string> { ["orderCode"] = "$.OrderCode" });
             var subscriber = new SubscriberBuilder()
                 .WithWebhooksSelectionRule("aSelectionRule")
                 .WithWebhooksUriTransform(uriTransform)
@@ -541,7 +541,7 @@ namespace CaptainHook.Application.Tests.Infrastructure
         [MemberData(nameof(Data))]
         public async Task MapSubscriberAsync_WithSingleCallbackAndInvalidUriTransform_MapsToRouteAndReplace(string httpVerb, AuthenticationEntity authentication, AuthenticationConfig expectedAuthenticationConfig)
         {
-            var uriTransform = new UriTransformEntity(null);
+            var uriTransform = new UriTransformEntity(new Dictionary<string, string> { ["orderCode"] = "$.OrderCode" });
             var subscriber = new SubscriberBuilder()
                 .WithWebhooksSelectionRule("aSelectionRule")
                 .WithWebhooksUriTransform(uriTransform)


### PR DESCRIPTION
The issue originally comes from the Domain layer that is directly taking the cosmos replace dictionary to instantiate a new UriTransform entity. This entity will then carry over an instance of ReadOnlyDictionary which will fail when the EntityToSubscriberConfiguration mapper tries to add the selector to the replacements dictionary.

With this PR I have enforced the concept of having a ReadOnlyDictionary even at the domain layer level (so the tests that we're not failing before because of improper mapping, will fail then)

Then I have delegated the EntityToSubscriberConfiguration mapper to make a copy of the replacements dictionary before the manipulation. This brought the tests back to passing.