### PR TITLE
#86705 - remove api consumer build code from coverage

### DIFF
--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/ApiConsumer.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/ApiConsumer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -33,6 +34,7 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda
 
         private static readonly string AssemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
+        [ExcludeFromCodeCoverage]
         public static ApiConsumer BuildApiConsumer(IHttpClientFactory clientFactory, string environment)
         {
             var configuration = EswDevOpsSdk.BuildConfiguration(AssemblyLocation, environment);

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaConfig.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaConfig.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using EShopworld.Security.Services.Rest;
 
 namespace Platform.Eda.Cli.Commands.ConfigureEda
 {
+    [ExcludeFromCodeCoverage]
     public class ConfigureEdaConfig
     {
         public Uri CaptainHookUrl { get; set; }


### PR DESCRIPTION
I have decided that the following areas should not be included in code coverage as it would only test our configuration or external packages which should be tested on their own.