### PR TITLE
#87252 Downgrade Swagger

### DIFF
--- a/src/CaptainHook.Api/CaptainHook.Api.csproj
+++ b/src/CaptainHook.Api/CaptainHook.Api.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights.ServiceFabric.Native" Version="2.3.1" />
     <PackageReference Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="4.0.470" />
     <PackageReference Include="Microsoft.ServiceFabric.Services" Version="4.0.470" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CaptainHook.Api/Startup.cs
+++ b/src/CaptainHook.Api/Startup.cs
@@ -145,10 +145,16 @@ namespace CaptainHook.Api
                                 new string[0]
                             }
                         });
-                        c.UseOneOfForPolymorphism();
-                        c.SelectSubTypesUsing(baseType =>
+                        c.GeneratePolymorphicSchemas(type =>
                         {
-                            return typeof(AuthenticationDto).Assembly.GetTypes().Where(type => type.IsSubclassOf(baseType));
+                            if (type == typeof(AuthenticationDto))
+                            {
+                                return new[] {
+                                    typeof(OidcAuthenticationDto),
+                                    typeof(BasicAuthenticationDto)
+                                };
+                            }
+                            return Enumerable.Empty<Type>();
                         });
 
                         c.OperationFilter<OperationIdFilter>();


### PR DESCRIPTION
We decided to downgrade Swagger to v.5.5.1 because any higher version will produce a swagger document which does not work with the embedded client.

This is the relevant commit: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/9de39ba546e56668fb42733352c6d6edc6d6757d#diff-dbf89e45f47e0cf293f917f0555996db