### PR TITLE
#73570 Avoid double DLQ suffix in service name

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
@@ -114,7 +114,7 @@ namespace CaptainHook.Application.Infrastructure.Mappers
             var subscriberConfiguration = SubscriberConfiguration.FromWebhookConfig(webhooksResult.Data);
             subscriberConfiguration.DLQMode = SubscriberDlqMode.WebHookMode;
             subscriberConfiguration.SourceSubscriptionName = entity.Name;
-            subscriberConfiguration.SubscriberName = $"{entity.Name}-DLQ";
+            subscriberConfiguration.SubscriberName = entity.Name;
 
             return subscriberConfiguration;
 


### PR DESCRIPTION
This change avoids the creation of event reader services with a double `-DLQ` suffix in the name. The code in `CaptainHook.Common\ServiceNaming.cs` is already taking care of appending said suffix for DLQ readers.