### PR TITLE
#87673 Add support for no authentication

### DIFF
--- a/src/CaptainHook.Api/AuthenticationDtoJsonConverter.cs
+++ b/src/CaptainHook.Api/AuthenticationDtoJsonConverter.cs
@@ -50,7 +50,8 @@ namespace CaptainHook.Api
             {
                 OidcAuthenticationDto.Type => new OidcAuthenticationDto(),
                 BasicAuthenticationDto.Type => new BasicAuthenticationDto(),
-                _ => null
+                NoAuthenticationDto.Type => new BasicAuthenticationDto(),
+                _ => null,
             };
 
             if (item != null)

--- a/src/CaptainHook.Api/AuthenticationDtoJsonConverter.cs
+++ b/src/CaptainHook.Api/AuthenticationDtoJsonConverter.cs
@@ -50,7 +50,7 @@ namespace CaptainHook.Api
             {
                 OidcAuthenticationDto.Type => new OidcAuthenticationDto(),
                 BasicAuthenticationDto.Type => new BasicAuthenticationDto(),
-                NoAuthenticationDto.Type => new BasicAuthenticationDto(),
+                NoAuthenticationDto.Type => new NoAuthenticationDto(),
                 _ => null,
             };
 

--- a/src/CaptainHook.Api/Startup.cs
+++ b/src/CaptainHook.Api/Startup.cs
@@ -151,7 +151,8 @@ namespace CaptainHook.Api
                             {
                                 return new[] {
                                     typeof(OidcAuthenticationDto),
-                                    typeof(BasicAuthenticationDto)
+                                    typeof(BasicAuthenticationDto),
+                                    typeof(NoAuthenticationDto)
                                 };
                             }
                             return Enumerable.Empty<Type>();

--- a/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
@@ -56,6 +56,7 @@ namespace CaptainHook.Application.Infrastructure.Mappers
             {
                 BasicAuthenticationDto dto => new BasicAuthenticationEntity(dto.Username, dto.PasswordKeyName),
                 OidcAuthenticationDto dto => new OidcAuthenticationEntity(dto.ClientId, dto.ClientSecretKeyName, dto.Uri, dto.Scopes?.ToArray()),
+                NoAuthenticationDto _ => null,
                 _ => null,
             };
         }

--- a/src/CaptainHook.Application.Infrastructure/Mappers/EntityToDtoMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/EntityToDtoMapper.cs
@@ -75,6 +75,7 @@ namespace CaptainHook.Application.Infrastructure.Mappers
                     Scopes = ent.Scopes?.ToList(),
                     ClientSecretKeyName = ent.ClientSecretKeyName
                 },
+                null => new NoAuthenticationDto(),
                 _ => null
             };
         }

--- a/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/SubscriberEntityToConfigurationMapper.cs
@@ -239,6 +239,7 @@ namespace CaptainHook.Application.Infrastructure.Mappers
             {
                 OidcAuthenticationEntity ent => (await MapOidcAuthenticationAsync(ent)).Then<AuthenticationConfig>(x => x),
                 BasicAuthenticationEntity ent => (await MapBasicAuthenticationAsync(ent)).Then<AuthenticationConfig>(x => x),
+                null => new AuthenticationConfig(),
                 _ => new MappingError("Could not find a suitable authentication mechanism.")
             };
         }

--- a/src/CaptainHook.Application/Validators/Dtos/EndpointDtoValidator.cs
+++ b/src/CaptainHook.Application/Validators/Dtos/EndpointDtoValidator.cs
@@ -16,7 +16,7 @@ namespace CaptainHook.Application.Validators.Dtos
                 .SetValidator(new UriValidator());
             RuleFor(x => x.Authentication).Cascade(CascadeMode.Stop)
                 .NotNull()
-                .WithMessage($"Authentication type must be one of these values: {BasicAuthenticationDto.Type}, {OidcAuthenticationDto.Type}.")
+                .WithMessage($"Authentication type must be one of these values: {NoAuthenticationDto.Type}, {BasicAuthenticationDto.Type}, {OidcAuthenticationDto.Type}.")
                 .SetValidator(new PolymorphicValidator<EndpointDto, AuthenticationDto>()
                     .Add(new BasicAuthenticationValidator())
                     .Add(new OidcAuthenticationValidator()));

--- a/src/CaptainHook.Application/Validators/Dtos/EndpointDtoValidator.cs
+++ b/src/CaptainHook.Application/Validators/Dtos/EndpointDtoValidator.cs
@@ -15,11 +15,11 @@ namespace CaptainHook.Application.Validators.Dtos
                 .NotEmpty()
                 .SetValidator(new UriValidator());
             RuleFor(x => x.Authentication).Cascade(CascadeMode.Stop)
-                .NotNull()
-                .WithMessage($"Authentication type must be one of these values: {NoAuthenticationDto.Type}, {BasicAuthenticationDto.Type}, {OidcAuthenticationDto.Type}.")
                 .SetValidator(new PolymorphicValidator<EndpointDto, AuthenticationDto>()
                     .Add(new BasicAuthenticationValidator())
-                    .Add(new OidcAuthenticationValidator()));
+                    .Add(new OidcAuthenticationValidator()))
+                .WithMessage($"Authentication type must be one of these values: {NoAuthenticationDto.Type}, {BasicAuthenticationDto.Type}, {OidcAuthenticationDto.Type}.");
+
         }
     }
 }

--- a/src/CaptainHook.Contract/NoAuthenticationDto.cs
+++ b/src/CaptainHook.Contract/NoAuthenticationDto.cs
@@ -1,0 +1,12 @@
+﻿namespace CaptainHook.Contract
+{
+    public class NoAuthenticationDto : AuthenticationDto
+    {
+        public const string Type = "None";
+        
+        public NoAuthenticationDto()
+        {
+            AuthenticationType = Type;
+        }
+    }
+}

--- a/src/CaptainHook.Storage.Cosmos/Models/EndpointSubdocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/EndpointSubdocument.cs
@@ -21,6 +21,7 @@ namespace CaptainHook.Storage.Cosmos.Models
         /// <summary>
         /// Endpoint authentication
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public AuthenticationSubdocument Authentication { get; set; }
 
         /// <summary>

--- a/src/Tests/CaptainHook.Application.Tests/AuthenticationConfigAssertions.cs
+++ b/src/Tests/CaptainHook.Application.Tests/AuthenticationConfigAssertions.cs
@@ -32,6 +32,7 @@ namespace CaptainHook.Application.Tests
             {
                 AuthenticationType.Basic => config is BasicAuthenticationConfig basicConfig && MatchesBasicAuthentication(basicConfig, (BasicAuthenticationConfig)expectation),
                 AuthenticationType.OIDC => config is OidcAuthenticationConfig oidcConfig && MatchesOidcAuthentication(oidcConfig, (OidcAuthenticationConfig)expectation),
+                AuthenticationType.None => config is AuthenticationConfig noneConfig && noneConfig.Type == AuthenticationType.None,
                 _ => false
             };
         }

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/DeleteSubscriberRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/DeleteSubscriberRequestHandlerTests.cs
@@ -30,7 +30,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         private readonly Mock<IEntityToDtoMapper> _entityToDtoMapperMock = new Mock<IEntityToDtoMapper>();
         private readonly Mock<ISubscriberEntityToConfigurationMapper> _entityToConfigurationMapperMock = new Mock<ISubscriberEntityToConfigurationMapper>();
 
-        private static OidcAuthenticationEntity _authentication = new OidcAuthenticationEntity(
+        private static readonly OidcAuthenticationEntity _authentication = new OidcAuthenticationEntity(
                 "captain-hook-id",
                 "kv-secret-name",
                 "https://blah-blah.sts.eshopworld.com",

--- a/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/DeleteWebhookRequestHandlerTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Handlers/Subscribers/DeleteWebhookRequestHandlerTests.cs
@@ -31,7 +31,7 @@ namespace CaptainHook.Application.Tests.Handlers.Subscribers
         private readonly Mock<IEntityToDtoMapper> _entityToDtoMapperMock = new Mock<IEntityToDtoMapper>();
         private readonly Mock<ISubscriberEntityToConfigurationMapper> _entityToConfigurationMapperMock = new Mock<ISubscriberEntityToConfigurationMapper>();
 
-        private static OidcAuthenticationEntity _authentication = new OidcAuthenticationEntity(
+        private static readonly OidcAuthenticationEntity _authentication = new OidcAuthenticationEntity(
                 "captain-hook-id",
                 "kv-secret-name",
                 "https://blah-blah.sts.eshopworld.com",

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
@@ -103,6 +103,31 @@ namespace CaptainHook.Application.Tests.Infrastructure
 
         [Fact]
         [IsUnit]
+        public void MapAuthentication_When_NoAuthenticationDtoIsUsed_Then_IsMappedToNull()
+        {
+            // Arrange
+            var dto = new NoAuthenticationDto();
+
+            // Act
+            var entity = sut.MapAuthentication(dto);
+
+            // Assert
+            entity.Should().BeNull();
+        }
+
+        [Fact]
+        [IsUnit]
+        public void MapAuthentication_When_NullIsUsed_Then_IsMappedToNull()
+        {
+            // Act
+            var entity = sut.MapAuthentication(null);
+
+            // Assert
+            entity.Should().BeNull();
+        }
+
+        [Fact]
+        [IsUnit]
         public void MapUriTransform_When_ValidUriTransformDtoIsUsed_Then_IsMappedToUriTransformEntity()
         {
             // Arrange

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests/MapSubscriberAsyncTestData.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests/MapSubscriberAsyncTestData.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using CaptainHook.Common.Authentication;
+using CaptainHook.Contract;
 using CaptainHook.Domain.Entities;
 
 namespace CaptainHook.Application.Tests.Infrastructure.SubscriberEntityToConfigurationMapperTests
@@ -28,6 +29,8 @@ namespace CaptainHook.Application.Tests.Infrastructure.SubscriberEntityToConfigu
         private static readonly BasicAuthenticationConfig BasicAuthenticationConfig =
             new BasicAuthenticationConfig { Username = "mark", Password = Secret, Type = AuthenticationType.Basic };
 
+        private static readonly AuthenticationConfig NoAuthenticationConfig = new AuthenticationConfig();
+
         public IEnumerator<object[]> GetEnumerator()
         {
             yield return new object[] { "POST", OidcAuthenticationEntity, OidcAuthenticationConfig };
@@ -36,6 +39,9 @@ namespace CaptainHook.Application.Tests.Infrastructure.SubscriberEntityToConfigu
             yield return new object[] { "POST", BasicAuthenticationEntity, BasicAuthenticationConfig };
             yield return new object[] { "GET", BasicAuthenticationEntity, BasicAuthenticationConfig };
             yield return new object[] { "PUT", BasicAuthenticationEntity, BasicAuthenticationConfig };
+            yield return new object[] { "POST", null, NoAuthenticationConfig };
+            yield return new object[] { "GET", null, NoAuthenticationConfig };
+            yield return new object[] { "PUT", null, NoAuthenticationConfig };
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
+++ b/src/Tests/CaptainHook.Storage.Cosmos.Tests/SubscriberRepositoryTests.cs
@@ -50,10 +50,13 @@ namespace CaptainHook.Storage.Cosmos.Tests
             {
                 new object[] { "POST", OidcAuthenticationEntity, OidcAuthenticationSubdocument },
                 new object[] { "POST", BasicAuthenticationEntity, BasicAuthenticationSubdocument },
+                new object[] { "POST", null, null },
                 new object[] { "PUT", OidcAuthenticationEntity, OidcAuthenticationSubdocument },
                 new object[] { "PUT", BasicAuthenticationEntity, BasicAuthenticationSubdocument },
+                new object[] { "PUT", null, null },
                 new object[] { "GET", OidcAuthenticationEntity, OidcAuthenticationSubdocument },
-                new object[] { "GET", BasicAuthenticationEntity, BasicAuthenticationSubdocument }
+                new object[] { "GET", BasicAuthenticationEntity, BasicAuthenticationSubdocument },
+                new object[] { "GET", null, null }
             };
 
         private SubscriberEntity CreateSubscriberEntity(string httpVerb = "POST", AuthenticationEntity authenticationEntity = null, string etag = null)

--- a/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Director/ConfigurationMergerTests.cs
@@ -35,6 +35,8 @@ namespace CaptainHook.Tests.Director
             Scopes = new[] { "scope1" }
         };
 
+        private static readonly AuthenticationConfig NoAuthenticationConfig = new AuthenticationConfig();
+
         private readonly Mock<ISecretProvider> _secretProvider;
         public static IEnumerable<object[]> Data =>
             new List<object[]>
@@ -44,7 +46,10 @@ namespace CaptainHook.Tests.Director
                 new object[] { "PUT", OidcAuthenticationEntity, OidcAuthenticationConfig },
                 new object[] { "POST", BasicAuthenticationEntity, BasicAuthenticationConfig },
                 new object[] { "GET", BasicAuthenticationEntity, BasicAuthenticationConfig },
-                new object[] { "PUT", BasicAuthenticationEntity, BasicAuthenticationConfig }
+                new object[] { "PUT", BasicAuthenticationEntity, BasicAuthenticationConfig },
+                new object[] { "POST", null, NoAuthenticationConfig },
+                new object[] { "GET", null, NoAuthenticationConfig },
+                new object[] { "PUT", null, NoAuthenticationConfig }
             };
 
         private static readonly WebhookRequestRule StatusCodeRequestRule = new WebhookRequestRule

--- a/src/Tests/CaptainHook.Tests/Json/AuthenticationDtoJsonConverterTests.cs
+++ b/src/Tests/CaptainHook.Tests/Json/AuthenticationDtoJsonConverterTests.cs
@@ -12,7 +12,7 @@ namespace CaptainHook.Tests.Json
     {
         [Fact]
         [IsUnit]
-        public void WhenAuthenticationIsOIDC_ThenItIsDeserializedProperly()
+        public void WhenAuthenticationTypeIsOIDC_ThenItIsDeserializedProperly()
         {
             string data = @"{
                 ""type"": ""OIDC"",
@@ -41,7 +41,7 @@ namespace CaptainHook.Tests.Json
 
         [Fact]
         [IsUnit]
-        public void WhenAuthenticationIsBasic_ThenItIsDeserializedProperly()
+        public void WhenAuthenticationTypeIsBasic_ThenItIsDeserializedProperly()
         {
             string data = @"{
                 ""type"": ""Basic"",
@@ -59,6 +59,23 @@ namespace CaptainHook.Tests.Json
                 var basicAuth = result as BasicAuthenticationDto;
                 basicAuth.Username.Should().Be("chuck");
                 basicAuth.PasswordKeyName.Should().Be("norris");
+            }
+        }
+
+        [Fact]
+        [IsUnit]
+        public void WhenAuthenticationTypeIsNone_ThenItIsDeserializedProperly()
+        {
+            string data = @"{
+                ""type"": ""None""
+            }";
+
+            var result = JsonConvert.DeserializeObject<AuthenticationDto>(data, new AuthenticationDtoJsonConverter());
+
+            using (new AssertionScope())
+            {
+                result.AuthenticationType.Should().Be(NoAuthenticationDto.Type);
+                result.Should().BeOfType<NoAuthenticationDto>();
             }
         }
 
@@ -85,12 +102,24 @@ namespace CaptainHook.Tests.Json
             result.Should().BeNull();
         }
 
+        [Fact, IsUnit]
+        public void WhenAuthenticationIsNull_ThenItIsDeserializedAsNoAuthentication()
+        {
+            var result = JsonConvert.DeserializeObject<AuthenticationWrapper>("{ authentication: null }", new AuthenticationDtoJsonConverter());
+
+            using (new AssertionScope())
+            {
+                result.Authentication.Should().NotBeNull();
+                result.Authentication.AuthenticationType.Should().Be(NoAuthenticationDto.Type);
+                result.Should().BeOfType<NoAuthenticationDto>();
+            }
+        }
+
         [Theory]
         [InlineData("{ authentication: 0 }")]
         [InlineData("{ authentication: \"invalid\" }")]
         [InlineData("{ authentication: \"\" }")]
         [InlineData("{ authentication: {} }")]
-        [InlineData("{ authentication: null }")]
         [IsUnit]
         public void WhenAuthenticationIsInvalid_ThenItIsDeserializedAsNull(string data)
         {

--- a/src/Tests/CaptainHook.Tests/Json/AuthenticationDtoJsonConverterTests.cs
+++ b/src/Tests/CaptainHook.Tests/Json/AuthenticationDtoJsonConverterTests.cs
@@ -102,24 +102,12 @@ namespace CaptainHook.Tests.Json
             result.Should().BeNull();
         }
 
-        [Fact, IsUnit]
-        public void WhenAuthenticationIsNull_ThenItIsDeserializedAsNoAuthentication()
-        {
-            var result = JsonConvert.DeserializeObject<AuthenticationWrapper>("{ authentication: null }", new AuthenticationDtoJsonConverter());
-
-            using (new AssertionScope())
-            {
-                result.Authentication.Should().NotBeNull();
-                result.Authentication.AuthenticationType.Should().Be(NoAuthenticationDto.Type);
-                result.Should().BeOfType<NoAuthenticationDto>();
-            }
-        }
-
         [Theory]
         [InlineData("{ authentication: 0 }")]
         [InlineData("{ authentication: \"invalid\" }")]
         [InlineData("{ authentication: \"\" }")]
         [InlineData("{ authentication: {} }")]
+        [InlineData("{ authentication: null }")]
         [IsUnit]
         public void WhenAuthenticationIsInvalid_ThenItIsDeserializedAsNull(string data)
         {


### PR DESCRIPTION
This PR adds support for no authentication.

No authentication is serialized as null to Cosmos.
The user can send a `{ type: "None" }` authentication section trough the API or null, both will translate to no authentication.