### PR TITLE
#88014 Apply fix for reader crash

### DIFF
--- a/src/CaptainHook.Common/ServiceBus/ServiceBusManager.cs
+++ b/src/CaptainHook.Common/ServiceBus/ServiceBusManager.cs
@@ -63,12 +63,16 @@ namespace CaptainHook.Common.ServiceBus
             var subscription = subscriptionsList.SingleOrDefault(s => string.Equals(s.Name, subscriptionName, StringComparison.OrdinalIgnoreCase));
             if (subscription != null) return subscription;
 
-            await topic.Subscriptions
-                .Define(subscriptionName.ToLowerInvariant())
-                .WithMessageLockDurationInSeconds(60)
-                .WithExpiredMessageMovedToDeadLetterSubscription()
-                .WithMessageMovedToDeadLetterSubscriptionOnMaxDeliveryCount(10)
-                .CreateAsync(cancellationToken);
+            try
+            {
+                await topic.Subscriptions
+                    .Define(subscriptionName.ToLowerInvariant())
+                    .WithMessageLockDurationInSeconds(60)
+                    .WithExpiredMessageMovedToDeadLetterSubscription()
+                    .WithMessageMovedToDeadLetterSubscriptionOnMaxDeliveryCount(10)
+                    .CreateAsync(cancellationToken);
+            }
+            catch { }
 
             await topic.RefreshAsync(cancellationToken);
             subscriptionsList = await topic.Subscriptions.ListAsync(cancellationToken: cancellationToken);
@@ -90,10 +94,14 @@ namespace CaptainHook.Common.ServiceBus
 
             if (topic != null) return topic;
 
-            await serviceBusNamespace.Topics
-                .Define(topicName.ToLowerInvariant())
-                .WithDuplicateMessageDetection(TimeSpan.FromMinutes(10))
-                .CreateAsync(cancellationToken);
+            try
+            {
+                await serviceBusNamespace.Topics
+                    .Define(topicName.ToLowerInvariant())
+                    .WithDuplicateMessageDetection(TimeSpan.FromMinutes(10))
+                    .CreateAsync(cancellationToken);
+            }
+            catch { }
 
             return await _findTopicPolicy.ExecuteAsync(ct => FindTopicAsync(serviceBusNamespace, topicName, ct), cancellationToken);
         }


### PR DESCRIPTION
There seem to be a race condition when the Director Service attempts to create more than one reader at the same time. The issue is when 2 or more reader service try to re-create the same topic and subscription at the same time, then SB gives out.

The proposed fix just swallows the exception which is only due to the race condition by assuming that the topic and subscription will be retrieved on the next step.

This does not want to be the best solution possible but at least a way to move forward at this stage. I will take the time to investigate separately a better solution to this issue.