### PR TITLE
CLI accepts params replacements

### DIFF
--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -10,6 +9,7 @@ using CaptainHook.Domain.Results;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Rest;
 using Platform.Eda.Cli.Commands.ConfigureEda.Models;
+using Platform.Eda.Cli.Commands.ConfigureEda.OptionsValidation;
 
 namespace Platform.Eda.Cli.Commands.ConfigureEda
 {
@@ -53,6 +53,15 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda
             ShowInHelpText = true)]
         public bool NoDryRun { get; set; }
 
+        /// <summary>
+        /// The environment name.
+        /// </summary>
+        [Option("-p|--params", CommandOptionType.MultipleValue,
+            Description = "The additional configuration parameters",
+            ShowInHelpText = true)]
+        [ReplacementParamsDictionary]
+        public string[] Params { get; set; }
+
         public async Task<int> OnExecuteAsync(IConsoleSubscriberWriter writer)
         {
             if (string.IsNullOrWhiteSpace(Environment))
@@ -61,6 +70,8 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda
             }
 
             writer.WriteSuccess("box", $"Reading files from folder: '{InputFolderPath}' to be run against {Environment} environment");
+
+            var replacements = BuildParametersReplacementDictionary(Params);
 
             var readDirectoryResult = _subscribersDirectoryProcessor.ProcessDirectory(InputFolderPath);
 
@@ -90,6 +101,11 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda
 
             writer.WriteSuccess("Processing finished");
             return 0;
+        }
+
+        private Dictionary<string, string> BuildParametersReplacementDictionary(string[] rawParams)
+        {
+            return rawParams.Select(p => p.Split('=')).ToDictionary(items => items[0], items => items[1]);
         }
 
         private async Task<List<OperationResult<HttpOperationResponse>>> ConfigureEdaWithCaptainHook(IConsoleSubscriberWriter writer,

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/ConfigureEdaCommand.cs
@@ -105,7 +105,7 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda
 
         private Dictionary<string, string> BuildParametersReplacementDictionary(string[] rawParams)
         {
-            return rawParams.Select(p => p.Split('=')).ToDictionary(items => items[0], items => items[1]);
+            return rawParams?.Select(p => p.Split('=')).ToDictionary(items => items[0], items => items[1]);
         }
 
         private async Task<List<OperationResult<HttpOperationResponse>>> ConfigureEdaWithCaptainHook(IConsoleSubscriberWriter writer,

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttribute.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+namespace Platform.Eda.Cli.Commands.ConfigureEda.OptionsValidation
+{
+    public class ReplacementParamsDictionaryAttribute : ValidationAttribute
+    {
+        private static readonly Regex KeyValueRegex = new Regex("^.+=.+$", RegexOptions.Compiled);
+
+        public ReplacementParamsDictionaryAttribute()
+            : base("The value for {0} must be a key and value separated by '='")
+        {
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext context)
+        {
+            if (value == null || (value is string str && !KeyValueRegex.IsMatch(str)))
+            {
+                return new ValidationResult(FormatErrorMessage(context.DisplayName));
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttribute.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttribute.cs
@@ -5,7 +5,7 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda.OptionsValidation
 {
     public class ReplacementParamsDictionaryAttribute : ValidationAttribute
     {
-        private static readonly Regex KeyValueRegex = new Regex("^.+=.+$", RegexOptions.Compiled);
+        private static readonly Regex KeyValueRegex = new Regex("^\\S+=\\S+$", RegexOptions.Compiled);
 
         public ReplacementParamsDictionaryAttribute()
             : base("The value for {0} must be a key and value separated by '='")

--- a/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttributeTests.cs
+++ b/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttributeTests.cs
@@ -8,10 +8,12 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.OptionsValidation
 {
     public class ReplacementParamsDictionaryAttributeTests
     {
-        [Fact, IsUnit]
-        public void ForValidParam_ReturnsTrue()
+        [Theory, IsUnit]
+        [InlineData("abc=def")]
+        [InlineData("my-domain=\"test.domain.com\"")]
+        public void ForValidParam_ReturnsTrue(string validValue)
         {
-            var result = new ReplacementParamsDictionaryAttribute().GetValidationResult("abc=def", new ValidationContext(new object()));
+            var result = new ReplacementParamsDictionaryAttribute().GetValidationResult(validValue, new ValidationContext(new object()));
 
             result.Should().Be(ValidationResult.Success);
         }
@@ -20,6 +22,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.OptionsValidation
         [InlineData("abc=")]
         [InlineData("=def")]
         [InlineData("abc")]
+        [InlineData("abc =def")]
         public void ForInvalidParam_ReturnsError(string invalidValue)
         {
             var result = new ReplacementParamsDictionaryAttribute().GetValidationResult(invalidValue, new ValidationContext(new object()));

--- a/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttributeTests.cs
+++ b/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/OptionsValidation/ReplacementParamsDictionaryAttributeTests.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using Platform.Eda.Cli.Commands.ConfigureEda.OptionsValidation;
+using Xunit;
+
+namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.OptionsValidation
+{
+    public class ReplacementParamsDictionaryAttributeTests
+    {
+        [Fact, IsUnit]
+        public void ForValidParam_ReturnsTrue()
+        {
+            var result = new ReplacementParamsDictionaryAttribute().GetValidationResult("abc=def", new ValidationContext(new object()));
+
+            result.Should().Be(ValidationResult.Success);
+        }
+
+        [Theory, IsUnit]
+        [InlineData("abc=")]
+        [InlineData("=def")]
+        [InlineData("abc")]
+        public void ForInvalidParam_ReturnsError(string invalidValue)
+        {
+            var result = new ReplacementParamsDictionaryAttribute().GetValidationResult(invalidValue, new ValidationContext(new object()));
+
+            result.Should().NotBe(ValidationResult.Success);
+        }
+    }
+}


### PR DESCRIPTION
There is no way to have a profit from this code currently, but as for now it can accept, validate and parse parameters from command line.

The syntax is: `configure-eda -i "C:/Temp" -p evo-host=test.eshopworld.com -p sample=value`