### PR TITLE
Add HEAD support to Probe

### DIFF
--- a/src/CaptainHook.Api/Controllers/ProbeController.cs
+++ b/src/CaptainHook.Api/Controllers/ProbeController.cs
@@ -15,6 +15,7 @@ namespace CaptainHook.Api.Controllers
         /// </summary>
         /// <returns>Returns status code 200</returns>
         [HttpGet]
+        [HttpHead]
         public IActionResult GetProbe()
         {
             return Ok("Healthy");


### PR DESCRIPTION
Adding support for HEAD probes as the app is currently configured for GET probes on AFD. Will remove GET support when DevOps updates AFD configuration. Discussed with Colin in DevOps.