### PR TITLE
#88608 Validate that all used parameters are defined

### DIFF
--- a/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/JsonValidation/FileReplacementsValidatorTests.cs
+++ b/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/JsonValidation/FileReplacementsValidatorTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
 {
-    public class FileVariablesValidatorTests
+    public class FileReplacementsValidatorTests
     {
 
         private readonly JObject _jsonObjectFile = JObject.Parse(@"
@@ -19,7 +19,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
             ""payloadTransform"": ""Response"",
             ""endpoints"": [
                 {
-                ""uri"": ""{vars:uri}{vars:path}/api/v2.0/WebHook/ClientOrderFailureMethod"",
+                ""uri"": ""{vars:uri}{params:evo-host}{vars:path}/api/v2.0/WebHook/ClientOrderFailureMethod"",
                 ""selector"": ""*"",
                 ""authentication"": ""{vars:sts-settings}"",
                 ""httpVerb"": ""POST""
@@ -30,7 +30,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
             ""selectionRule"": ""$.TenantCode"",
             ""endpoints"": [
                 {
-                ""uri"": ""{vars:uri}{vars:path}/api/v2/EdaResponse/ExternalEdaResponse"",
+                ""uri"": ""{vars:uri}{params:evo-host}{vars:path}/api/v2/EdaResponse/ExternalEdaResponse"",
                 ""selector"": ""*"",
                 ""httpVerb"": ""POST""
                 }
@@ -40,7 +40,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
             ""selectionRule"": ""$.TenantCode"",
             ""endpoints"": [
                 {
-                ""uri"": ""{vars:uri}/api/v2/DlqRequest/ExternalRequest"",
+                ""uri"": ""{vars:uri}{params:evo-host}/api/v2/DlqRequest/ExternalRequest"",
                 ""selector"": ""*"",
                 ""httpVerb"": ""POST""
                 }
@@ -58,7 +58,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
                 {  "path", JToken.Parse("\"thepath\"") },
                 {  "sts-settings", JToken.Parse("{ \"type\": \"None\" }") },
             };
-            var validator = new FileVariablesValidator(replacements);
+            var validator = new FileReplacementsValidator(replacements);
 
             // Act
             var result = validator.TestValidate(_jsonObjectFile);
@@ -76,7 +76,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
                 {  "path", JToken.Parse("\"thepath\"") },
                 {  "sts-settings", JToken.Parse("{ \"type\": \"None\" }") },
             };
-            var validator = new FileVariablesValidator(replacements);
+            var validator = new FileReplacementsValidator(replacements);
 
             // Act
             var result = validator.TestValidate(_jsonObjectFile);
@@ -90,7 +90,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
         {
             // Arrange
             var replacements = new Dictionary<string, JToken>();
-            var validator = new FileVariablesValidator(replacements);
+            var validator = new FileReplacementsValidator(replacements);
 
             // Act
             var result = validator.TestValidate(_jsonObjectFile);
@@ -100,6 +100,37 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
                 .WithErrorMessage("File must declare variable 'uri'.")
                 .WithErrorMessage("File must declare variable 'path'.")
                 .WithErrorMessage("File must declare variable 'sts-settings'.");
+        }
+
+        [Fact, IsUnit]
+        public void Validate_When_AllParametersAreDefined_Then_NoErrorIsReturned()
+        {
+            // Arrange
+            var replacements = new Dictionary<string, string>()
+            {
+                {  "evo-host", "domain.company.com" }
+            };
+            var validator = new FileReplacementsValidator(replacements);
+
+            // Act
+            var result = validator.TestValidate(_jsonObjectFile);
+
+            // Assert
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact, IsUnit]
+        public void Validate_When_ParameterIsNotDefined_Then_ErrorIsReturned()
+        {
+            // Arrange
+            var replacements = new Dictionary<string, string>();
+            var validator = new FileReplacementsValidator(replacements);
+
+            // Act
+            var result = validator.TestValidate(_jsonObjectFile);
+
+            // Assert
+            result.ShouldHaveAnyValidationError().WithErrorMessage("File must declare parameter 'evo-host'.");
         }
     }
 }


### PR DESCRIPTION
This amends the variable validator with 2 constructors:
- one will accept variables dictionary and perform the already implemented validation
- the other one will accept parameters dictionary and perform the parameters validation

> Note: the validator has not been added to the main chain to minimize merge conflicts.