### PR TITLE
#88607 - validate that all used variables are defined in json file

### DIFF
--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonProcessor/PutSubscriberProcessChain.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonProcessor/PutSubscriberProcessChain.cs
@@ -109,6 +109,14 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda.JsonProcessor
                     continue;
                 }
 
+                // Step 2.1 - validate vars
+                var varsValidationResult = await new FileVariablesValidator(extractVarsResult.Data).ValidateAsync(parsedFile);
+                if (!varsValidationResult.IsValid)
+                {
+                    _console.WriteValidationResult("JSON file processing", varsValidationResult);
+                    continue;
+                }
+
                 // Step 3 - Replace vars and params
                 var template = parsedFile.ToString();
                 var templateReplaceResult = _jsonTemplateValuesReplacer.Replace("vars", template, extractVarsResult.Data);

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonValidation/FileVariablesValidator.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonValidation/FileVariablesValidator.cs
@@ -1,0 +1,61 @@
+﻿using FluentValidation;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Platform.Eda.Cli.Commands.ConfigureEda.JsonValidation
+{
+    public class FileVariablesValidator : AbstractValidator<JObject>
+    {
+        private readonly static Regex VariablesRegex = new Regex("{vars:([^{}:]+)}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private readonly Dictionary<string, JToken> _variables;
+
+        public FileVariablesValidator(Dictionary<string, JToken> variables)
+        {
+            _variables = variables;
+
+            RuleForEach(x => GetUsedVariables(x).Distinct())
+                .Must(HaveVariableDeclared)
+                .WithName("Variables")
+                .WithMessage(UndeclaredVariableMessage);
+        }
+
+        private static string UndeclaredVariableMessage(JObject fileObject, string variableName)
+        {
+            return $"File must declare variable '{variableName}'.";
+        }
+
+        private static IEnumerable<string> GetUsedVariables(JObject obj)
+        {
+            var toSearch = new Stack<JToken>(obj.Children());
+            while (toSearch.Count > 0)
+            {
+                var inspected = toSearch.Pop();
+
+                if (inspected.Type == JTokenType.Property &&
+                    (JProperty)inspected is var property &&
+                    property.Value.Type == JTokenType.String &&
+                    VariablesRegex.Matches((string)property.Value) is var matches &&
+                    matches.Any())
+                {
+                    foreach (Match match in matches)
+                    {
+                        yield return match.Groups[1].Value;
+                    }
+                }
+
+                foreach (var child in inspected)
+                {
+                    toSearch.Push(child);
+                }
+            }
+        }
+
+        private bool HaveVariableDeclared(string variableName)
+        {
+            return _variables.Any(x => x.Key.Equals(variableName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/JsonValidation/FileVariablesValidatorTests.cs
+++ b/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/JsonValidation/FileVariablesValidatorTests.cs
@@ -1,0 +1,105 @@
+﻿using Eshopworld.Tests.Core;
+using FluentValidation.TestHelper;
+using Newtonsoft.Json.Linq;
+using Platform.Eda.Cli.Commands.ConfigureEda.JsonValidation;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
+{
+    public class FileVariablesValidatorTests
+    {
+
+        private readonly JObject _jsonObjectFile = JObject.Parse(@"
+        {
+            ""eventName"": ""eshopworld.someeventname"",
+            ""subscriberName"": ""retailers"",
+            ""webhooks"": {
+            ""selectionRule"": ""$.TenantCode"",
+            ""payloadTransform"": ""Response"",
+            ""endpoints"": [
+                {
+                ""uri"": ""{vars:uri}{vars:path}/api/v2.0/WebHook/ClientOrderFailureMethod"",
+                ""selector"": ""*"",
+                ""authentication"": ""{vars:sts-settings}"",
+                ""httpVerb"": ""POST""
+                },
+            ]
+            },
+            ""callbacks"": {
+            ""selectionRule"": ""$.TenantCode"",
+            ""endpoints"": [
+                {
+                ""uri"": ""{vars:uri}{vars:path}/api/v2/EdaResponse/ExternalEdaResponse"",
+                ""selector"": ""*"",
+                ""httpVerb"": ""POST""
+                }
+            ]
+            },
+            ""dlqhooks"": {
+            ""selectionRule"": ""$.TenantCode"",
+            ""endpoints"": [
+                {
+                ""uri"": ""{vars:uri}/api/v2/DlqRequest/ExternalRequest"",
+                ""selector"": ""*"",
+                ""httpVerb"": ""POST""
+                }
+            ]
+            }
+        }");
+
+        [Fact, IsUnit]
+        public void Validate_When_AllVariablesAreDefined_Then_NoErrorIsReturned()
+        {
+            // Arrange
+            var replacements = new Dictionary<string, JToken>()
+            {
+                {  "uri", JToken.Parse("\"http://www.api.com\"") },
+                {  "path", JToken.Parse("\"thepath\"") },
+                {  "sts-settings", JToken.Parse("{ \"type\": \"None\" }") },
+            };
+            var validator = new FileVariablesValidator(replacements);
+
+            // Act
+            var result = validator.TestValidate(_jsonObjectFile);
+
+            // Assert
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact, IsUnit]
+        public void Validate_When_VariableIsNotDefined_Then_ErrorIsReturned()
+        {
+            // Arrange
+            var replacements = new Dictionary<string, JToken>()
+            {
+                {  "path", JToken.Parse("\"thepath\"") },
+                {  "sts-settings", JToken.Parse("{ \"type\": \"None\" }") },
+            };
+            var validator = new FileVariablesValidator(replacements);
+
+            // Act
+            var result = validator.TestValidate(_jsonObjectFile);
+
+            // Assert
+            result.ShouldHaveAnyValidationError().WithErrorMessage("File must declare variable 'uri'.");
+        }
+
+        [Fact, IsUnit]
+        public void Validate_When_AllVariablesAreNotDefined_Then_ErrorsAreReturned()
+        {
+            // Arrange
+            var replacements = new Dictionary<string, JToken>();
+            var validator = new FileVariablesValidator(replacements);
+
+            // Act
+            var result = validator.TestValidate(_jsonObjectFile);
+
+            // Assert
+            result.ShouldHaveAnyValidationError()
+                .WithErrorMessage("File must declare variable 'uri'.")
+                .WithErrorMessage("File must declare variable 'path'.")
+                .WithErrorMessage("File must declare variable 'sts-settings'.");
+        }
+    }
+}


### PR DESCRIPTION
Recreating this PR due to merge issues.

From @tabman83
This implements a validator that validates that all the variables used by the subscriber JSON file appear in the variables declaration.
The validator has not been added to the main chain to minimize merge conflicts.