### PR TITLE
Task 88607 validate params for json files

### DIFF
--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonProcessor/PutSubscriberProcessChain.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonProcessor/PutSubscriberProcessChain.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Threading.Tasks;
 using CaptainHook.Domain.Results;
 using Castle.Core.Internal;
+using FluentValidation.Results;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Rest;
 using Newtonsoft.Json;
@@ -109,11 +110,13 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda.JsonProcessor
                     continue;
                 }
 
-                // Step 2.1 - validate vars
-                var varsValidationResult = await new FileVariablesValidator(extractVarsResult.Data).ValidateAsync(parsedFile);
-                if (!varsValidationResult.IsValid)
+                // Step 2.1 - validate vars and params
+                var varsValidationResult = await new FileReplacementsValidator(extractVarsResult.Data).ValidateAsync(parsedFile);
+                var paramsValidationResult = await new FileReplacementsValidator(replacementParams ?? new Dictionary<string, string>()).ValidateAsync(parsedFile);
+                var replacementValidationResult = new ValidationResult(varsValidationResult.Errors.Concat(paramsValidationResult.Errors));
+                if (!replacementValidationResult.IsValid)
                 {
-                    _console.WriteValidationResult("JSON file processing", varsValidationResult);
+                    _console.WriteValidationResult("JSON file processing", replacementValidationResult);
                     continue;
                 }
 

--- a/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonValidation/FileReplacementsValidator.cs
+++ b/src/Platform.Eda.Cli/Commands/ConfigureEda/JsonValidation/FileReplacementsValidator.cs
@@ -7,19 +7,31 @@ using System.Text.RegularExpressions;
 
 namespace Platform.Eda.Cli.Commands.ConfigureEda.JsonValidation
 {
-    public class FileVariablesValidator : AbstractValidator<JObject>
+    public class FileReplacementsValidator : AbstractValidator<JObject>
     {
         private readonly static Regex VariablesRegex = new Regex("{vars:([^{}:]+)}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private readonly static Regex ParametersRegex = new Regex("{params:([^{}:]+)}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private readonly Dictionary<string, JToken> _variables;
+        private readonly Dictionary<string, string> _parameters;
 
-        public FileVariablesValidator(Dictionary<string, JToken> variables)
+        public FileReplacementsValidator(Dictionary<string, JToken> variables)
         {
             _variables = variables;
 
-            RuleForEach(x => GetUsedVariables(x).Distinct())
+            RuleForEach(x => GetUsedReplacements(x, VariablesRegex).Distinct())
                 .Must(HaveVariableDeclared)
                 .WithName("Variables")
                 .WithMessage(UndeclaredVariableMessage);
+        }
+
+        public FileReplacementsValidator(Dictionary<string, string> parameters)
+        {
+            _parameters = parameters;
+
+            RuleForEach(x => GetUsedReplacements(x, ParametersRegex).Distinct())
+                .Must(HaveParameterDeclared)
+                .WithName("Parameters")
+                .WithMessage(UndeclaredParameterMessage);
         }
 
         private static string UndeclaredVariableMessage(JObject fileObject, string variableName)
@@ -27,7 +39,12 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda.JsonValidation
             return $"File must declare variable '{variableName}'.";
         }
 
-        private static IEnumerable<string> GetUsedVariables(JObject obj)
+        private static string UndeclaredParameterMessage(JObject fileObject, string parameterName)
+        {
+            return $"CLI run must provide parameter '{parameterName}'.";
+        }
+
+        private static IEnumerable<string> GetUsedReplacements(JObject obj, Regex replacementRegex)
         {
             var toSearch = new Stack<JToken>(obj.Children());
             while (toSearch.Count > 0)
@@ -37,7 +54,7 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda.JsonValidation
                 if (inspected.Type == JTokenType.Property &&
                     (JProperty)inspected is var property &&
                     property.Value.Type == JTokenType.String &&
-                    VariablesRegex.Matches((string)property.Value) is var matches &&
+                    replacementRegex.Matches((string)property.Value) is var matches &&
                     matches.Any())
                 {
                     foreach (Match match in matches)
@@ -51,6 +68,11 @@ namespace Platform.Eda.Cli.Commands.ConfigureEda.JsonValidation
                     toSearch.Push(child);
                 }
             }
+        }
+
+        private bool HaveParameterDeclared(string parameterName)
+        {
+            return _parameters.Any(x => x.Key.Equals(parameterName, StringComparison.OrdinalIgnoreCase));
         }
 
         private bool HaveVariableDeclared(string variableName)

--- a/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/JsonValidation/FileReplacementsValidatorTests.cs
+++ b/src/Tests/Platform.Eda.Cli.Tests/Commands/ConfigureEda/JsonValidation/FileReplacementsValidatorTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
 {
-    public class FileVariablesValidatorTests
+    public class FileReplacementsValidatorTests
     {
 
         private readonly JObject _jsonObjectFile = JObject.Parse(@"
@@ -19,7 +19,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
             ""payloadTransform"": ""Response"",
             ""endpoints"": [
                 {
-                ""uri"": ""{vars:uri}{vars:path}/api/v2.0/WebHook/ClientOrderFailureMethod"",
+                ""uri"": ""{vars:uri}{params:evo-host}{vars:path}/api/v2.0/WebHook/ClientOrderFailureMethod"",
                 ""selector"": ""*"",
                 ""authentication"": ""{vars:sts-settings}"",
                 ""httpVerb"": ""POST""
@@ -30,7 +30,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
             ""selectionRule"": ""$.TenantCode"",
             ""endpoints"": [
                 {
-                ""uri"": ""{vars:uri}{vars:path}/api/v2/EdaResponse/ExternalEdaResponse"",
+                ""uri"": ""{vars:uri}{params:evo-host}{vars:path}/api/v2/EdaResponse/ExternalEdaResponse"",
                 ""selector"": ""*"",
                 ""httpVerb"": ""POST""
                 }
@@ -40,7 +40,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
             ""selectionRule"": ""$.TenantCode"",
             ""endpoints"": [
                 {
-                ""uri"": ""{vars:uri}/api/v2/DlqRequest/ExternalRequest"",
+                ""uri"": ""{vars:uri}{params:evo-host}/api/v2/DlqRequest/ExternalRequest"",
                 ""selector"": ""*"",
                 ""httpVerb"": ""POST""
                 }
@@ -58,7 +58,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
                 {  "path", JToken.Parse("\"thepath\"") },
                 {  "sts-settings", JToken.Parse("{ \"type\": \"None\" }") },
             };
-            var validator = new FileVariablesValidator(replacements);
+            var validator = new FileReplacementsValidator(replacements);
 
             // Act
             var result = validator.TestValidate(_jsonObjectFile);
@@ -76,7 +76,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
                 {  "path", JToken.Parse("\"thepath\"") },
                 {  "sts-settings", JToken.Parse("{ \"type\": \"None\" }") },
             };
-            var validator = new FileVariablesValidator(replacements);
+            var validator = new FileReplacementsValidator(replacements);
 
             // Act
             var result = validator.TestValidate(_jsonObjectFile);
@@ -90,7 +90,7 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
         {
             // Arrange
             var replacements = new Dictionary<string, JToken>();
-            var validator = new FileVariablesValidator(replacements);
+            var validator = new FileReplacementsValidator(replacements);
 
             // Act
             var result = validator.TestValidate(_jsonObjectFile);
@@ -100,6 +100,37 @@ namespace Platform.Eda.Cli.Tests.Commands.ConfigureEda.JsonValidation
                 .WithErrorMessage("File must declare variable 'uri'.")
                 .WithErrorMessage("File must declare variable 'path'.")
                 .WithErrorMessage("File must declare variable 'sts-settings'.");
+        }
+
+        [Fact, IsUnit]
+        public void Validate_When_AllParametersAreDefined_Then_NoErrorIsReturned()
+        {
+            // Arrange
+            var replacements = new Dictionary<string, string>()
+            {
+                {  "evo-host", "domain.company.com" }
+            };
+            var validator = new FileReplacementsValidator(replacements);
+
+            // Act
+            var result = validator.TestValidate(_jsonObjectFile);
+
+            // Assert
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact, IsUnit]
+        public void Validate_When_ParameterIsNotDefined_Then_ErrorIsReturned()
+        {
+            // Arrange
+            var replacements = new Dictionary<string, string>();
+            var validator = new FileReplacementsValidator(replacements);
+
+            // Act
+            var result = validator.TestValidate(_jsonObjectFile);
+
+            // Assert
+            result.ShouldHaveAnyValidationError().WithErrorMessage("CLI run must provide parameter 'evo-host'.");
         }
     }
 }


### PR DESCRIPTION
Creating a new PR for this as I had issues with merge conflicts.

After @tabman83 
This amends the variable validator with 2 constructors:

- one will accept variables dictionary and perform the already implemented validation
- the other one will accept parameters dictionary and perform the parameters validation 

Example: 
![image](https://user-images.githubusercontent.com/60343978/95472408-4bae1e00-0983-11eb-9f13-b0730983f221.png)
