### PR TITLE
#89814 - introduce retry-sleep-durations in webhook configuration

### DIFF
--- a/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
+++ b/src/CaptainHook.Common/Configuration/EventHandlerConfig.cs
@@ -13,10 +13,13 @@ namespace CaptainHook.Common.Configuration
     /// </summary>
     public class WebhookConfig
     {
+        private static readonly TimeSpan[] DefaultRetrySleepDurations = { TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(30) };
+
         public WebhookConfig()
         {
             AuthenticationConfig = new AuthenticationConfig();
             WebhookRequestRules = new List<WebhookRequestRule>();
+            RetrySleepDurations = DefaultRetrySleepDurations;
         }
 
         /// <summary>
@@ -82,6 +85,12 @@ namespace CaptainHook.Common.Configuration
         /// </summary>
         [JsonProperty(Order = 6)]
         public TimeSpan Timeout { get; set; } = new TimeSpan(0, 0, 100);
+
+        /// <summary>
+        /// Retry sleep durations to use for request retry logic
+        /// </summary>
+        [JsonProperty(Order = 7)]
+        public TimeSpan[] RetrySleepDurations { get; set; }
 
         /// <summary>
         /// type of transformation to perform onto payload

--- a/src/CaptainHook.EventHandlerActor/Handlers/Authentication/MmAuthenticationHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Authentication/MmAuthenticationHandler.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Common;
 using CaptainHook.Common.Authentication;
+using CaptainHook.Common.Configuration;
 using CaptainHook.Common.Telemetry.Web;
 using Eshopworld.Core;
 using Newtonsoft.Json;
@@ -44,12 +45,10 @@ namespace CaptainHook.EventHandlerActor.Handlers.Authentication
             headers.AddRequestHeader("client_id", OidcAuthenticationConfig.ClientId);
             headers.AddRequestHeader("client_secret", OidcAuthenticationConfig.ClientSecret);
 
+            var defaultRetrySleepDurations = new WebhookConfig().RetrySleepDurations;
             var authProviderResponse = await HttpSender.SendAsync(
-                HttpMethod.Post,
-                new Uri(OidcAuthenticationConfig.Uri),
-                headers,
-                string.Empty,
-                cancellationToken: cancellationToken);
+                new SendRequest(HttpMethod.Post, new Uri(OidcAuthenticationConfig.Uri), headers, string.Empty, defaultRetrySleepDurations),
+                cancellationToken);
 
             if (authProviderResponse.StatusCode != HttpStatusCode.Created || authProviderResponse.Content == null)
             {

--- a/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
@@ -78,7 +78,9 @@ namespace CaptainHook.EventHandlerActor.Handlers
 
                 await AddAuthenticationHeaderAsync(cancellationToken, authenticationConfig, headers);
 
-                var response = await HttpSender.SendAsync(httpMethod, uri, headers, payload, config.Timeout, cancellationToken);
+                var response = await HttpSender.SendAsync(
+                    new SendRequest(httpMethod, uri, headers, payload, config.RetrySleepDurations, config.Timeout),
+                    cancellationToken);
 
                 await _requestLogger.LogAsync(response, messageData, payload, uri, httpMethod, headers, config);
 

--- a/src/CaptainHook.EventHandlerActor/Handlers/IHttpSender.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/IHttpSender.cs
@@ -8,7 +8,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
 {
     public interface IHttpSender
     {
-        public Task<HttpResponseMessage> SendAsync(HttpMethod httpMethod, Uri uri, WebHookHeaders headers, string payload, TimeSpan timeout = default, CancellationToken cancellationToken = default);
+        public Task<HttpResponseMessage> SendAsync(SendRequest sendRequest, CancellationToken cancellationToken = default);
 
         public Task<TokenResponse> RequestClientCredentialsTokenAsync(ClientCredentialsTokenRequest request, CancellationToken cancellationToken = default);
     }

--- a/src/CaptainHook.EventHandlerActor/Handlers/SendRequest.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/SendRequest.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net.Http;
+using JetBrains.Annotations;
+
+namespace CaptainHook.EventHandlerActor.Handlers
+{
+    public class SendRequest
+    {
+        public SendRequest(
+            HttpMethod httpMethod,
+            Uri uri,
+            WebHookHeaders headers,
+            string payload,
+            [NotNull]TimeSpan[] retrySleepDurations,
+            TimeSpan timeout = default)
+        {
+            HttpMethod = httpMethod;
+            Uri = uri;
+            Headers = headers;
+            Payload = payload;
+            Timeout = timeout;
+            RetrySleepDurations = retrySleepDurations ?? throw new ArgumentNullException(nameof(retrySleepDurations), "Retry sleep durations are required");
+        }
+
+        public HttpMethod HttpMethod { get; }
+
+        public Uri Uri { get; }
+
+        public WebHookHeaders Headers { get; }
+
+        public string Payload { get; }
+
+        public TimeSpan Timeout { get; }
+
+        public TimeSpan[] RetrySleepDurations { get; }
+    }
+}

--- a/src/CaptainHook.EventHandlerActor/Handlers/WebhookResponseHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/WebhookResponseHandler.cs
@@ -48,7 +48,9 @@ namespace CaptainHook.EventHandlerActor.Handlers
 
             await AddAuthenticationHeaderAsync(cancellationToken, authenticationConfig, headers);
 
-            var response = await HttpSender.SendAsync(httpMethod, uri, headers, payload, config.Timeout, cancellationToken);
+            var response = await HttpSender.SendAsync(
+                new SendRequest(httpMethod, uri, headers, payload, config.RetrySleepDurations, config.Timeout),
+                cancellationToken);
 
             await _requestLogger.LogAsync(response, messageData, payload, uri, httpMethod, headers, config);
 

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebhookHandlerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/GenericWebhookHandlerTests.cs
@@ -179,7 +179,7 @@ namespace CaptainHook.Tests.Web.WebHooks
 
             var httpSender = new Mock<IHttpSender>();
             httpSender
-                .Setup(x => x.SendAsync(It.IsAny<HttpMethod>(), It.IsAny<Uri>(), It.IsAny<WebHookHeaders>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                .Setup(x => x.SendAsync(It.IsAny<SendRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError))
                 .Verifiable();
 

--- a/src/Tests/CaptainHook.Tests/Web/WebHooks/WebhookResponseHandlerTests.cs
+++ b/src/Tests/CaptainHook.Tests/Web/WebHooks/WebhookResponseHandlerTests.cs
@@ -111,7 +111,12 @@ namespace CaptainHook.Tests.Web.WebHooks
             await webhookResponseHandler.CallAsync(messageData, new Dictionary<string, object>(), _cancellationToken);
 
             _mockAuthHandlerFactory.Verify(e => e.GetAsync(messageData.SubscriberConfig, _cancellationToken), Times.Once);
-            _mockHttpSender.Verify(x => x.SendAsync(It.Is<SendRequest>(request => request.Uri == new Uri(ExpectedWebHookUri)), It.IsAny<CancellationToken>()), Times.Once);
+            _mockHttpSender.Verify(x => x.SendAsync(
+                    It.Is<SendRequest>(request =>
+                        request.HttpMethod == HttpMethod.Post &&
+                        request.Uri == new Uri(ExpectedWebHookUri)),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR does not enable usage of the config yet in Http Sender