### PR TITLE
#89814 - use retry config in sender

### DIFF
--- a/src/Tests/CaptainHook.EventHandlerActor.Tests/CaptainHook.EventHandlerActor.Tests.csproj
+++ b/src/Tests/CaptainHook.EventHandlerActor.Tests/CaptainHook.EventHandlerActor.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Eshopworld.Tests.Core" Version="2.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="ServiceFabric.Mocks" Version="4.2.3" />

--- a/src/Tests/CaptainHook.EventHandlerActor.Tests/HttpSenderTests.cs
+++ b/src/Tests/CaptainHook.EventHandlerActor.Tests/HttpSenderTests.cs
@@ -70,5 +70,31 @@ namespace CaptainHook.EventHandlerActor.Tests
             messageResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
             _mockHttp.GetMatchCount(request).Should().Be(2);
         }
+
+        [Fact, IsUnit]
+        public async Task SendAsync_InvalidResponseButNoRetries_HappensOnce()
+        {
+            // Arrange
+            var request = _mockHttp.When("https://eshop.abc")
+                .Respond(HttpStatusCode.InternalServerError);
+
+            _factoryMock.Setup(f => f.Get(new Uri("https://eshop.abc"), default))
+                .Returns(new HttpClient(_mockHttp));
+
+            // Act
+            var subject = new HttpSender(_factoryMock.Object);
+            var messageResponse = await subject.SendAsync(
+                new SendRequest(
+                    HttpMethod.Get,
+                    new Uri("https://eshop.abc"),
+                    new WebHookHeaders(),
+                    string.Empty,
+                    new TimeSpan[0]));
+
+            // Assert
+            using var _ = new AssertionScope();
+            messageResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            _mockHttp.GetMatchCount(request).Should().Be(1);
+        }
     }
 }

--- a/src/Tests/CaptainHook.EventHandlerActor.Tests/HttpSenderTests.cs
+++ b/src/Tests/CaptainHook.EventHandlerActor.Tests/HttpSenderTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CaptainHook.EventHandlerActor.Handlers;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Moq;
+using RichardSzalay.MockHttp;
+using Xunit;
+using IHttpClientFactory = CaptainHook.EventHandlerActor.Handlers.IHttpClientFactory;
+
+namespace CaptainHook.EventHandlerActor.Tests
+{
+    public class HttpSenderTests
+    {
+        private readonly MockHttpMessageHandler _mockHttp = new MockHttpMessageHandler();
+
+        private readonly Mock<IHttpClientFactory> _factoryMock = new Mock<IHttpClientFactory>();
+
+        [Fact, IsUnit]
+        public async Task SendAsync_ValidResponse_HappensOnce()
+        {
+            // Arrange
+            var request = _mockHttp.When("https://eshop.abc")
+                .Respond("application/json", "{'prop' : 'abc'}");
+
+            _factoryMock.Setup(f => f.Get(new Uri("https://eshop.abc"), default))
+                .Returns(new HttpClient(_mockHttp));
+
+            // Act
+            var subject = new HttpSender(_factoryMock.Object);
+            var messageResponse = await subject.SendAsync(
+                new SendRequest(
+                    HttpMethod.Get,
+                    new Uri("https://eshop.abc"),
+                    new WebHookHeaders(),
+                    string.Empty,
+                    new[] { TimeSpan.FromMilliseconds(100) }));
+
+            // Assert
+            using var _ = new AssertionScope();
+            messageResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            _mockHttp.GetMatchCount(request).Should().Be(1);
+        }
+
+        [Fact, IsUnit]
+        public async Task SendAsync_InvalidResponse_HappensTwoTimes()
+        {
+            // Arrange
+            var request = _mockHttp.When("https://eshop.abc")
+                .Respond(HttpStatusCode.InternalServerError);
+
+            _factoryMock.Setup(f => f.Get(new Uri("https://eshop.abc"), default))
+                .Returns(new HttpClient(_mockHttp));
+
+            // Act
+            var subject = new HttpSender(_factoryMock.Object);
+            var messageResponse = await subject.SendAsync(
+                new SendRequest(
+                    HttpMethod.Get,
+                    new Uri("https://eshop.abc"),
+                    new WebHookHeaders(),
+                    string.Empty,
+                    new[] { TimeSpan.FromMilliseconds(100) }));
+
+            // Assert
+            using var _ = new AssertionScope();
+            messageResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            _mockHttp.GetMatchCount(request).Should().Be(2);
+        }
+    }
+}

--- a/src/Tests/CaptainHook.EventHandlerActor.Tests/SendRequestTests.cs
+++ b/src/Tests/CaptainHook.EventHandlerActor.Tests/SendRequestTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Net.Http;
+using CaptainHook.EventHandlerActor.Handlers;
+using Eshopworld.Tests.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace CaptainHook.EventHandlerActor.Tests
+{
+    public class SendRequestTests
+    {
+        [Fact, IsUnit]
+        public void SendRequest_ConstructorNoRetryDurations_ThrowsException()
+        {
+            // Act
+            Func<SendRequest> func = () => new SendRequest(HttpMethod.Get, new Uri("https://eshop.abc"), new WebHookHeaders(), string.Empty, null, default);
+
+            // Assert
+            func.Should().Throw<ArgumentNullException>().WithMessage("Retry sleep durations are required *");
+        }
+    }
+}


### PR DESCRIPTION
With this change, the sender is going to use the config for retries instead of the hardcoded values.

Note:
The HTTP mock library does not seem to allow for subsequent requests to have different responses. If anybody knows how to enable that please let me know, I could then add an additional test which verifies that the status code changes e.g. (1) 500 (2) 200 and no (3) is required.