### PR TITLE
#91260 - extend DTOs with Timeout and RetrySleepDurations

### DIFF
--- a/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
+++ b/src/CaptainHook.Application.Infrastructure/Mappers/DtoToEntityMapper.cs
@@ -19,7 +19,13 @@ namespace CaptainHook.Application.Infrastructure.Mappers
         public EndpointEntity MapEndpoint(EndpointDto endpointDto, string selector = null)
         {
             var authenticationEntity = MapAuthentication(endpointDto.Authentication);
-            var endpoint = new EndpointEntity(endpointDto.Uri, authenticationEntity, endpointDto.HttpVerb, selector ?? endpointDto.Selector);
+            var endpoint = new EndpointEntity(
+                endpointDto.Uri,
+                authenticationEntity,
+                endpointDto.HttpVerb,
+                selector ?? endpointDto.Selector,
+                endpointDto.RetrySleepDurations,
+                endpointDto.Timeout);
 
             return endpoint;
         }

--- a/src/CaptainHook.Contract/EndpointDto.cs
+++ b/src/CaptainHook.Contract/EndpointDto.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace CaptainHook.Contract
 {
@@ -28,5 +29,15 @@ namespace CaptainHook.Contract
         /// Selector
         /// </summary>
         public string Selector { get; set; }
+
+        /// <summary>
+        /// Http call timeout. When not provided the default is 1m 20s.
+        /// </summary>
+        public TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Http call retries and wait time between those. When not provided the default of 2 additional retries is used, the first one of 20s and the second 30s.
+        /// </summary>
+        public TimeSpan[] RetrySleepDurations { get; set; }
     }
 }

--- a/src/CaptainHook.Storage.Cosmos/Models/EndpointSubdocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/EndpointSubdocument.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace CaptainHook.Storage.Cosmos.Models
 {
@@ -28,5 +29,17 @@ namespace CaptainHook.Storage.Cosmos.Models
         /// Endpoint HTTP verb
         /// </summary>
         public string HttpVerb { get; set; }
+
+        /// <summary>
+        /// Http Timeout
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Retry sleep durations
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public TimeSpan[] RetrySleepDurations { get; set; }
     }
 }

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -257,7 +257,9 @@ namespace CaptainHook.Storage.Cosmos
                 Selector = endpointEntity.Selector,
                 HttpVerb = endpointEntity.HttpVerb,
                 Uri = endpointEntity.Uri,
-                Authentication = MapToAuthenticationSubdocument(endpointEntity.Authentication)
+                Authentication = MapToAuthenticationSubdocument(endpointEntity.Authentication),
+                Timeout = endpointEntity.Timeout,
+                RetrySleepDurations = endpointEntity.RetrySleepDurations
             };
         }
 

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/DtoToEntityMapperTests.cs
@@ -1,4 +1,5 @@
-﻿using CaptainHook.Application.Infrastructure.Mappers;
+using System;
+using CaptainHook.Application.Infrastructure.Mappers;
 using CaptainHook.TestsInfrastructure.Builders;
 using FluentAssertions.Execution;
 using CaptainHook.Domain.Entities;
@@ -168,6 +169,31 @@ namespace CaptainHook.Application.Tests.Infrastructure
                 entity.Selector.Should().Be("Select");
                 entity.Uri.Should().Be("http://www.test.url");
                 entity.HttpVerb.Should().Be(httpVerb);
+                entity.Timeout.Should().BeNull();
+                entity.RetrySleepDurations.Should().BeNull();
+            }
+        }
+
+        [Fact]
+        [IsUnit]
+        public void MapEndpoint_When_TimeoutAndRetriesProvided_Then_AreMappedToEndpointEntity()
+        {
+            // Arrange
+            var dto = new EndpointDtoBuilder()
+                .With(x => x.HttpVerb, "PUT")
+                .With(x => x.Uri, "http://www.test.url")
+                .With(x => x.Timeout, TimeSpan.FromSeconds(10))
+                .With(x => x.RetrySleepDurations, new[] { TimeSpan.FromSeconds(1) })
+                .Create();
+
+            // Act
+            var entity = sut.MapEndpoint(dto, null);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                entity.Timeout.Should().Be(TimeSpan.FromSeconds(10));
+                entity.RetrySleepDurations.Should().BeEquivalentTo(new[] { TimeSpan.FromSeconds(1) });
             }
         }
 


### PR DESCRIPTION
I have checked and the values are saved correctly to Cosmos. When properties are not provided they are skipped on serialisation as well.