### PR TITLE
Fix subscribers merge issue

### DIFF
--- a/src/CaptainHook.DirectorService/Infrastructure/ConfigurationMerger.cs
+++ b/src/CaptainHook.DirectorService/Infrastructure/ConfigurationMerger.cs
@@ -33,8 +33,10 @@ namespace CaptainHook.DirectorService.Infrastructure
         {
             var onlyInKv = subscribersFromKeyVault
                 .Where(kvSubscriber => !subscribersFromCosmos.Any(cosmosSubscriber =>
-                    kvSubscriber.EventType.Equals(cosmosSubscriber.ParentEvent.Name, StringComparison.InvariantCultureIgnoreCase)
-                    && kvSubscriber.SubscriberName.Equals(cosmosSubscriber.Name, StringComparison.InvariantCultureIgnoreCase)));
+                    kvSubscriber.EventType.Equals(cosmosSubscriber.ParentEvent.Name, StringComparison.InvariantCultureIgnoreCase) && 
+                    (kvSubscriber.SubscriberName.Equals(cosmosSubscriber.Name, StringComparison.InvariantCultureIgnoreCase) ||
+                     (!string.IsNullOrEmpty(kvSubscriber.SourceSubscriptionName) && kvSubscriber.SourceSubscriptionName.Equals(cosmosSubscriber.Name, StringComparison.InvariantCultureIgnoreCase)))
+                ));
 
             async Task<OperationResult<IEnumerable<SubscriberConfiguration>>> MapCosmosEntries()
             {


### PR DESCRIPTION
Fixes an issue while merging subscribers from KV and Cosmos where the DLQ subscriber is not recognized when already present in KV. The merger will now consider the SourceSubscriptionName in KV when present (and that's only there for DLQ subscribers) and match it with the SubscriptionName in Cosmos.