### PR TITLE
#91761 - allow routes not to specify default selector

### DIFF
--- a/src/CaptainHook.Application/Validators/Dtos/WebhooksDtoValidator.cs
+++ b/src/CaptainHook.Application/Validators/Dtos/WebhooksDtoValidator.cs
@@ -27,7 +27,7 @@ namespace CaptainHook.Application.Validators.Dtos
                 .NotEmpty()
                 .WithMessage($"{subject} list must contain at least one endpoint")
                 .Must(ContainAtMostOneEndpointWithDefaultSelector)
-                    .WithMessage("There can be only one endpoint with the default selector")
+                    .WithMessage("There can be at most one endpoint with the default selector")
                 .Must(NotContainMultipleEndpointsWithTheSameSelector)
                     .WithMessage("There cannot be multiple endpoints with the same selector");
 

--- a/src/CaptainHook.EventHandlerActor/Handlers/Requests/RouteAndReplaceRequestBuilder.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/Requests/RouteAndReplaceRequestBuilder.cs
@@ -38,6 +38,13 @@ namespace CaptainHook.EventHandlerActor.Handlers.Requests
             var webhookConfig = GetWebhookConfig(routeAndReplaceRule, selector);
 
             void PublishUnroutableEventWithMessage(string message) => PublishUnroutableEvent(config, message, selector);
+
+            if (webhookConfig == null)
+            {
+                PublishUnroutableEventWithMessage($"No route found for selector '{selector}'");
+                return null;
+            }
+
             var replacementDictionary = BuildReplacementDictionary(routeAndReplaceRule.Source.Replace, payload, PublishUnroutableEventWithMessage);
 
             return new BuildUriContext(
@@ -88,7 +95,7 @@ namespace CaptainHook.EventHandlerActor.Handlers.Requests
             if (route == null)
             {
                 var defaultRoute =
-                    rule.Routes.First(r => r.Selector.Equals(DefaultFallbackSelectorKey, StringComparison.OrdinalIgnoreCase));
+                    rule.Routes.FirstOrDefault(r => r.Selector.Equals(DefaultFallbackSelectorKey, StringComparison.OrdinalIgnoreCase));
                 return defaultRoute;
             }
 

--- a/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertSubscriberRequestValidatorTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertSubscriberRequestValidatorTests.cs
@@ -210,7 +210,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
             var result = _validator.TestValidate(request);
 
             result.ShouldHaveValidationErrorFor(x => x.Subscriber.Webhooks.Endpoints)
-                .WithErrorMessage("There can be only one endpoint with the default selector");
+                .WithErrorMessage("There can be at most one endpoint with the default selector");
         }
 
         [Fact, IsUnit]
@@ -228,7 +228,7 @@ namespace CaptainHook.Application.Tests.RequestValidators
             var result = _validator.TestValidate(request);
 
             result.ShouldHaveValidationErrorFor(x => x.Subscriber.Webhooks.Endpoints)
-                .WithErrorMessage("There can be only one endpoint with the default selector");
+                .WithErrorMessage("There can be at most one endpoint with the default selector");
         }
 
         [Fact, IsUnit]

--- a/src/Tests/CaptainHook.EventHandlerActor.Tests/Validation/WebhookRequestRuleForRouteAndReplaceValidatorTests.cs
+++ b/src/Tests/CaptainHook.EventHandlerActor.Tests/Validation/WebhookRequestRuleForRouteAndReplaceValidatorTests.cs
@@ -159,7 +159,7 @@ namespace CaptainHook.EventHandlerActor.Tests.Validation
         }
 
         [Fact, IsUnit]
-        public void When_there_is_no_default_Route_Selector_then_validation_should_fail()
+        public void When_there_is_no_default_Route_Selector_then_validation_should_succeed()
         {
             var rule = new WebhookRequestRuleBuilder()
                 .WithSource(sourceBuilder => sourceBuilder
@@ -177,7 +177,7 @@ namespace CaptainHook.EventHandlerActor.Tests.Validation
 
             var result = _validator.TestValidate(rule);
 
-            result.ShouldHaveValidationErrorFor(x => x.Routes);
+            result.ShouldNotHaveValidationErrorFor(x => x.Routes);
         }
 
         [Fact, IsUnit]
@@ -199,7 +199,9 @@ namespace CaptainHook.EventHandlerActor.Tests.Validation
 
             var result = _validator.TestValidate(rule);
 
-            result.ShouldHaveValidationErrorFor(x => x.Routes);
+            result
+                .ShouldHaveValidationErrorFor(x => x.Routes)
+                .WithErrorMessage("At most one route can use default selector");
         }
 
         [Theory, IsUnit]
@@ -247,7 +249,9 @@ namespace CaptainHook.EventHandlerActor.Tests.Validation
 
             var result = _validator.TestValidate(rule);
 
-            result.ShouldHaveValidationErrorFor(x => x.Routes);
+            result
+                .ShouldHaveValidationErrorFor(x => x.Routes)
+                .WithErrorMessage("All routes must have unique selectors");
         }
     }
 }


### PR DESCRIPTION
We are introducing a change with this PR which will:

1. stop requiring exactly one default selector * in RouteAndReplace
1. send a UnroutableEvent to AI if a message comes in which doesn't match the configuration (and we don't have * to fall back)