### PR TITLE
#91261 #91264 Extend subscriber with MaxDeliveryCount functionality

### DIFF
--- a/src/CaptainHook.Application/Handlers/Subscribers/UpsertSubscriberRequestHandler.cs
+++ b/src/CaptainHook.Application/Handlers/Subscribers/UpsertSubscriberRequestHandler.cs
@@ -73,10 +73,12 @@ namespace CaptainHook.Application.Handlers.Subscribers
 
         private SubscriberEntity MapRequestToEntity(UpsertSubscriberRequest request)
         {
+            var subscriberEntity = new SubscriberEntity(request.SubscriberName, new EventEntity(request.EventName))
+            {
+                MaxDeliveryCount = request.Subscriber.MaxDeliveryCount
+            };
+
             var webhooks = _dtoToEntityMapper.MapWebooks(request.Subscriber.Webhooks, WebhooksEntityType.Webhooks);
-
-            var subscriberEntity = new SubscriberEntity(request.SubscriberName, new EventEntity(request.EventName));
-
             subscriberEntity.SetHooks(webhooks);
 
             if (request.Subscriber.Callbacks?.Endpoints?.Count > 0)

--- a/src/CaptainHook.Application/Validators/Dtos/SubscriberDtoValidator.cs
+++ b/src/CaptainHook.Application/Validators/Dtos/SubscriberDtoValidator.cs
@@ -16,6 +16,10 @@ namespace CaptainHook.Application.Validators.Dtos
 
             RuleFor(x => x.DlqHooks)
                 .SetValidator(new WebhooksDtoValidator(WebhooksValidatorDtoType.DlqHook));
+
+            RuleFor(x => x.MaxDeliveryCount)
+                .Cascade(CascadeMode.Stop)
+                .GreaterThanOrEqualTo(1).When(entity => entity.MaxDeliveryCount.HasValue);
         }
     }
 }

--- a/src/CaptainHook.Contract/SubscriberDto.cs
+++ b/src/CaptainHook.Contract/SubscriberDto.cs
@@ -1,4 +1,6 @@
-﻿namespace CaptainHook.Contract
+﻿using Newtonsoft.Json;
+
+namespace CaptainHook.Contract
 {
     public class SubscriberDto
     {
@@ -7,5 +9,8 @@
         public WebhooksDto Callbacks { get; set; }
         
         public WebhooksDto DlqHooks { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? MaxDeliveryCount { get; set; }
     }
 }

--- a/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
+++ b/src/CaptainHook.Domain/Entities/SubscriberEntity.cs
@@ -23,6 +23,11 @@ namespace CaptainHook.Domain.Entities
         public string Etag { get; }
 
         /// <summary>
+        /// Get max delivery count
+        /// </summary>
+        public int? MaxDeliveryCount { get; set; }
+
+        /// <summary>
         /// Parent event for this subscriber
         /// </summary>
         public EventEntity ParentEvent { get; private set; }

--- a/src/CaptainHook.Domain/Entities/WebhooksEntity.cs
+++ b/src/CaptainHook.Domain/Entities/WebhooksEntity.cs
@@ -34,11 +34,6 @@ namespace CaptainHook.Domain.Entities
         public string PayloadTransform { get; private set; }
 
         /// <summary>
-        /// Max delivery count for webhooks
-        /// </summary>
-        public int? MaxDeliveryCount { get; private set; }
-
-        /// <summary>
         /// Type of entity
         /// </summary>
         public WebhooksEntityType Type { get; }
@@ -60,14 +55,14 @@ namespace CaptainHook.Domain.Entities
 
         public WebhooksEntity(WebhooksEntityType type, string selectionRule, IEnumerable<EndpointEntity> endpoints) : this(type, selectionRule, endpoints, null, null) { }
 
-        public WebhooksEntity(WebhooksEntityType type, string selectionRule, IEnumerable<EndpointEntity> endpoints, UriTransformEntity uriTransform,
-            string payloadTransform = null, int? maxDeliveryCount = null) : this(type)
+        public WebhooksEntity(WebhooksEntityType type, string selectionRule, IEnumerable<EndpointEntity> endpoints,
+            UriTransformEntity uriTransform,
+            string payloadTransform = null) : this(type)
         {
             SelectionRule = selectionRule;
             Endpoints = endpoints?.ToList();
             UriTransform = uriTransform;
             PayloadTransform = (type == WebhooksEntityType.Callbacks) ? null : (payloadTransform ?? "$");
-            MaxDeliveryCount = (type == WebhooksEntityType.Webhooks) ? maxDeliveryCount : null;
         }
 
         public WebhooksEntity SetSelectionRule(string selectionRule)
@@ -115,20 +110,11 @@ namespace CaptainHook.Domain.Entities
             }
         }
 
-        public void SetMaxDeliveryCount(int? maxDeliveryCount)
-        {
-            if (Type == WebhooksEntityType.Webhooks)
-            {
-                MaxDeliveryCount = maxDeliveryCount;
-            }
-        }
-
         public OperationResult<WebhooksEntity> SetHooks(WebhooksEntity webhooks, SubscriberEntity subscriberEntity = null)
         {
             SetSelectionRule(webhooks.SelectionRule);
             SetUriTransform(webhooks.UriTransform);
             SetPayloadTransform(webhooks.PayloadTransform);
-            SetMaxDeliveryCount(webhooks.MaxDeliveryCount);
             Endpoints.Clear();
             foreach (var endpoint in webhooks.Endpoints)
             {

--- a/src/CaptainHook.Storage.Cosmos/Models/SubscriberDocument.cs
+++ b/src/CaptainHook.Storage.Cosmos/Models/SubscriberDocument.cs
@@ -52,6 +52,12 @@ namespace CaptainHook.Storage.Cosmos.Models
         public WebhookSubdocument DlqHooks { get; set; }
 
         /// <summary>
+        /// Max delivery count for subscriber.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? MaxDeliveryCount { get; set; }
+
+        /// <summary>
         /// ETag of the document from Cosmos Db
         /// </summary>
         [JsonProperty("_etag")]

--- a/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
+++ b/src/CaptainHook.Storage.Cosmos/SubscriberRepository.cs
@@ -228,7 +228,8 @@ namespace CaptainHook.Storage.Cosmos
                 Webhooks = Map(subscriberEntity.Webhooks),
                 Callbacks = Map(subscriberEntity.Callbacks),
                 DlqHooks = Map(subscriberEntity.DlqHooks),
-                Etag = subscriberEntity.Etag
+                Etag = subscriberEntity.Etag,
+                MaxDeliveryCount = subscriberEntity.MaxDeliveryCount
             };
         }
 
@@ -275,7 +276,10 @@ namespace CaptainHook.Storage.Cosmos
             var subscriberEntity = new SubscriberEntity(
                 subscriberDocument.SubscriberName,
                 eventEntity,
-                subscriberDocument.Etag);
+                subscriberDocument.Etag)
+            {
+                MaxDeliveryCount = subscriberDocument.MaxDeliveryCount
+            };
 
             subscriberEntity.SetHooks(Map(subscriberDocument.Webhooks, subscriberEntity, WebhooksEntityType.Webhooks));
 

--- a/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests/WebhookAndCallbacksMapSubscriberAsyncTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/Infrastructure/SubscriberEntityToConfigurationMapperTests/WebhookAndCallbacksMapSubscriberAsyncTests.cs
@@ -1003,7 +1003,7 @@ namespace CaptainHook.Application.Tests.Infrastructure.SubscriberEntityToConfigu
             var subscriber = new SubscriberBuilder()
                 .WithWebhooksUriTransform(uriTransform)
                 .WithWebhook("https://order-{selector}.eshopworld.com/webhook/", httpVerb, null, authentication)
-                .WithWebhooksMaxDeliveryCount(20)
+                .WithMaxDeliveryCount(20)
                 .Create();
 
             var result = await new SubscriberEntityToConfigurationMapper(_secretProviderMock.Object).MapToWebhookAsync(subscriber);

--- a/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertSubscriberRequestValidatorTests.cs
+++ b/src/Tests/CaptainHook.Application.Tests/RequestValidators/UpsertSubscriberRequestValidatorTests.cs
@@ -484,5 +484,34 @@ namespace CaptainHook.Application.Tests.RequestValidators
             result.ShouldHaveValidationErrorFor(x => x.Subscriber.Webhooks.PayloadTransform);
             result.ShouldHaveValidationErrorFor(x => x.Subscriber.DlqHooks.PayloadTransform);
         }
+
+        [Theory, IsUnit]
+        [InlineData(null)]
+        [InlineData(1)]
+        [InlineData(5)]
+        [InlineData(100)]
+        public void When_MaxDeliveryIsValid_Then_ValidationSucceeds(int? maxDelivery)
+        {
+            var dto = new SubscriberDtoBuilder().With(x => x.MaxDeliveryCount, maxDelivery).Create();
+            var request = new UpsertSubscriberRequest("event", "subscriber", dto);
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldNotHaveValidationErrorFor(x => x.Subscriber.MaxDeliveryCount);
+        }
+
+        [Theory, IsUnit]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void When_MaxDeliveryIsNotValid_Then_ValidationFails(int maxDelivery)
+        {
+            var dto = new SubscriberDtoBuilder().With(x => x.MaxDeliveryCount, maxDelivery).Create();
+            var request = new UpsertSubscriberRequest("event", "subscriber", dto);
+
+            var result = _validator.TestValidate(request);
+
+            result.ShouldHaveValidationErrorFor(x => x.Subscriber.MaxDeliveryCount)
+                .WithErrorMessage("'Max Delivery Count' must be greater than or equal to '1'.");
+        }
     }
 }

--- a/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
+++ b/src/Tests/CaptainHook.Tests/Services/Reliable/EventReaderInitDataTests.cs
@@ -109,6 +109,7 @@ namespace CaptainHook.Tests.Services.Reliable
             eventReaderInitData.SubscriberName.Should().Be(_subscriberConfiguration.SubscriberName);
             eventReaderInitData.EventType.Should().Be(_subscriberConfiguration.EventType);
             eventReaderInitData.SubscriberConfiguration.Should().BeEquivalentTo(_subscriberConfiguration);
+            eventReaderInitData.MaxDeliveryCount.Should().Be(_subscriberConfiguration.MaxDeliveryCount);
         }
 
         [Fact]

--- a/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberBuilder.cs
+++ b/src/Tests/CaptainHook.TestsInfrastructure/Builders/SubscriberBuilder.cs
@@ -40,7 +40,7 @@ namespace CaptainHook.TestsInfrastructure.Builders
             return this;
         }
 
-        public SubscriberBuilder WithWebhooksMaxDeliveryCount(int maxDeliveryCount)
+        public SubscriberBuilder WithMaxDeliveryCount(int maxDeliveryCount)
         {
             _webhookMaxDeliveryCount = maxDeliveryCount;
             return this;
@@ -117,10 +117,13 @@ namespace CaptainHook.TestsInfrastructure.Builders
 
         public SubscriberEntity Create()
         {
-            var subscriber = new SubscriberEntity(_name, _event, _etag);
+            var subscriber = new SubscriberEntity(_name, _event, _etag)
+            {
+                MaxDeliveryCount = _webhookMaxDeliveryCount
+            };
 
             return subscriber.SetHooks(
-                    new WebhooksEntity(WebhooksEntityType.Webhooks, _webhookSelectionRule, _webhooks, _webhooksUriTransformEntity, _webhookPayloadTransform, _webhookMaxDeliveryCount))
+                    new WebhooksEntity(WebhooksEntityType.Webhooks, _webhookSelectionRule, _webhooks, _webhooksUriTransformEntity, _webhookPayloadTransform))
                 .Then(_ => subscriber.SetHooks(
                     new WebhooksEntity(WebhooksEntityType.Callbacks, _callbackSelectionRule, _callbacks, _callbacksUriTransformEntity, null)))
                 .Then(_ => subscriber.SetHooks(


### PR DESCRIPTION
I have tested the following scenarios:

- new subscriber added via API with no MaxDeliveryCount (default 10 used)
- new subscriber added via API with valid and invalid MaxDeliveryCount
- subscriber updated via API with MaxDeliveryCount
- subscriber updated via API with no MaxDeliveryCount
- manual change in CosmosDB and restart of CH results in proper values in SB
- regular KV entries with no MaxDeliveryCount result in default 10

For each of the above, I have tested that the subscriber in SB is refreshed with the relevant MaxDeliveryCount value.