### PR TITLE
New event and logging

### DIFF
--- a/src/CaptainHook.Common/Telemetry/FailedWebhookExceptionEvent.cs
+++ b/src/CaptainHook.Common/Telemetry/FailedWebhookExceptionEvent.cs
@@ -4,9 +4,9 @@ using Newtonsoft.Json;
 
 namespace CaptainHook.Common.Telemetry
 {
-    public class FailedWebhookExceptionEvent : TelemetryEvent
+    public class HttpSendFailureEvent : TelemetryEvent
     {
-        public FailedWebhookExceptionEvent(string uri, Exception exception)
+        public HttpSendFailureEvent(string uri, Exception exception)
         {
             Uri = uri;
             Exception = JsonConvert.SerializeObject(exception, new JsonSerializerSettings()

--- a/src/CaptainHook.Common/Telemetry/FailedWebhookExceptionEvent.cs
+++ b/src/CaptainHook.Common/Telemetry/FailedWebhookExceptionEvent.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Eshopworld.Core;
+using Newtonsoft.Json;
+
+namespace CaptainHook.Common.Telemetry
+{
+    public class FailedWebhookExceptionEvent : TelemetryEvent
+    {
+        public FailedWebhookExceptionEvent(string uri, Exception exception)
+        {
+            Uri = uri;
+            Exception = JsonConvert.SerializeObject(exception, new JsonSerializerSettings()
+            {
+                ContractResolver = new NoReferencesJsonContractResolver(),
+                PreserveReferencesHandling = PreserveReferencesHandling.None,
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+            });
+        }
+
+        public string Uri { get; set; }
+
+        public string Exception { get; set; }
+    }
+}

--- a/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using CaptainHook.Common;
 using CaptainHook.Common.Authentication;
 using CaptainHook.Common.Configuration;
+using CaptainHook.Common.Telemetry;
 using CaptainHook.EventHandlerActor.Handlers.Authentication;
 using Eshopworld.Core;
 using Eshopworld.Platform.Messages;
@@ -53,6 +54,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
         /// <returns></returns>
         public virtual async Task<bool> CallAsync<TRequest>(TRequest request, IDictionary<string, object> metadata, CancellationToken cancellationToken)
         {
+            Uri uri = null;
             try
             {
                 if (!(request is MessageData messageData))
@@ -61,7 +63,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 }
 
                 //todo refactor into a single call and a dto
-                var uri = RequestBuilder.BuildUri(WebhookConfig, messageData.Payload);
+                uri = RequestBuilder.BuildUri(WebhookConfig, messageData.Payload);
                 if (uri == null)
                 {
                     return true; //consider successful delivery
@@ -88,7 +90,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
             }
             catch (Exception e)
             {
-                BigBrother.Publish(e.ToExceptionEvent());
+                BigBrother.Publish(new FailedWebhookExceptionEvent(uri?.AbsoluteUri, e));
                 throw;
             }
         }

--- a/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
+++ b/src/CaptainHook.EventHandlerActor/Handlers/GenericWebhookHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using CaptainHook.Common;
@@ -81,8 +82,8 @@ namespace CaptainHook.EventHandlerActor.Handlers
                 await AddAuthenticationHeaderAsync(cancellationToken, authenticationConfig, headers);
 
                 var response = await HttpSender.SendAsync(
-                    new SendRequest(httpMethod, uri, headers, payload, config.RetrySleepDurations, config.Timeout),
-                    cancellationToken);
+                     new SendRequest(httpMethod, uri, headers, payload, config.RetrySleepDurations, config.Timeout),
+                     cancellationToken);
 
                 await _requestLogger.LogAsync(response, messageData, payload, uri, httpMethod, headers, config);
 
@@ -90,7 +91,7 @@ namespace CaptainHook.EventHandlerActor.Handlers
             }
             catch (Exception e)
             {
-                BigBrother.Publish(new FailedWebhookExceptionEvent(uri?.AbsoluteUri, e));
+                BigBrother.Publish(new HttpSendFailureEvent(uri?.AbsoluteUri, e));
                 throw;
             }
         }


### PR DESCRIPTION
Now exception details as well as the invoked uri are logged in `FailedWebhookExceptionEvent`

![image](https://user-images.githubusercontent.com/63288056/100738667-38915a80-33d6-11eb-9496-fea07ae65274.png)
